### PR TITLE
Module decoupling

### DIFF
--- a/Assets/Scripts.meta
+++ b/Assets/Scripts.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8bcc187d197ecf2299249e4391c888d7
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core.meta
+++ b/Assets/Scripts/Core.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bde24bef91308e512b3394a582b4d2a2
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Core.asmdef
+++ b/Assets/Scripts/Core/Core.asmdef
@@ -1,0 +1,14 @@
+{
+    "name": "Core",
+    "rootNamespace": "Core",
+    "references": [],
+    "includePlatforms": [],
+    "excludePlatforms": [],
+    "allowUnsafeCode": false,
+    "overrideReferences": false,
+    "precompiledReferences": [],
+    "autoReferenced": true,
+    "defineConstraints": [],
+    "versionDefines": [],
+    "noEngineReferences": false
+}

--- a/Assets/Scripts/Core/Core.asmdef.meta
+++ b/Assets/Scripts/Core/Core.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: ab2730e25ea9ed57d91eb4c2607a458e
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Test.cs
+++ b/Assets/Scripts/Core/Test.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace OperationBlackwell.Core {
+	public class Test : MonoBehaviour {
+		void Start() {
+			Debug.Log("Hello World!");
+		}
+	}
+}

--- a/Assets/Scripts/Core/Test.cs.meta
+++ b/Assets/Scripts/Core/Test.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4dac7ad8b5b3ea13684b2fab42f2b9cd
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Testing.cs
+++ b/Assets/Scripts/Testing.cs
@@ -1,0 +1,13 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using OperationBlackwell.Core;
+
+namespace OperationBlackwell {
+	public class Testing : MonoBehaviour {
+		void Start() {
+			Debug.Log("Hello World!");
+			Test test = new Test();
+		}
+	}
+}

--- a/Assets/Scripts/Testing.cs.meta
+++ b/Assets/Scripts/Testing.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b8a4eb1703482d8448960e31f9d57739
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Packages/manifest.json
+++ b/Packages/manifest.json
@@ -7,6 +7,7 @@
     "com.unity.test-framework": "1.1.29",
     "com.unity.textmeshpro": "3.0.6",
     "com.unity.timeline": "1.4.8",
+    "com.unity.toolchain.linux-x86_64": "0.1.19-preview",
     "com.unity.ugui": "1.0.0",
     "com.unity.modules.ai": "1.0.0",
     "com.unity.modules.androidjni": "1.0.0",

--- a/Packages/packages-lock.json
+++ b/Packages/packages-lock.json
@@ -39,6 +39,22 @@
       "dependencies": {},
       "url": "https://packages.unity.com"
     },
+    "com.unity.sysroot": {
+      "version": "0.1.19-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {},
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.sysroot.linux-x86_64": {
+      "version": "0.1.14-preview",
+      "depth": 1,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "0.1.18-preview"
+      },
+      "url": "https://packages.unity.com"
+    },
     "com.unity.test-framework": {
       "version": "1.1.29",
       "depth": 0,
@@ -68,6 +84,16 @@
         "com.unity.modules.animation": "1.0.0",
         "com.unity.modules.audio": "1.0.0",
         "com.unity.modules.particlesystem": "1.0.0"
+      },
+      "url": "https://packages.unity.com"
+    },
+    "com.unity.toolchain.linux-x86_64": {
+      "version": "0.1.19-preview",
+      "depth": 0,
+      "source": "registry",
+      "dependencies": {
+        "com.unity.sysroot": "0.1.19-preview",
+        "com.unity.sysroot.linux-x86_64": "0.1.14-preview"
       },
       "url": "https://packages.unity.com"
     },


### PR DESCRIPTION
This PR adds a system to organise different modules inside the game and helps keep the code base cleaner by creating barriers between those modules. Although there are still ways to couple them, but only to those modules that depend on that module.