### PR TITLE
More fancy grid features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -77,3 +77,6 @@ crashlytics-build.properties
 # Map files are not needed for now
 /[Aa]ssets/[Ss]avesWorld/
 /[Aa]ssets/[Ss]avesWorld.meta
+
+# Ignore my Build storage please
+/[Bb]uilds/

--- a/.gitignore
+++ b/.gitignore
@@ -73,3 +73,7 @@ crashlytics-build.properties
 # Temporary auto-generated Android Assets
 /[Aa]ssets/[Ss]treamingAssets/aa.meta
 /[Aa]ssets/[Ss]treamingAssets/aa/*
+
+# Map files are not needed for now
+/[Aa]ssets/[Ss]avesWorld/
+/[Aa]ssets/[Ss]avesWorld.meta

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -267,6 +267,128 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   gameController_: {fileID: 593590127}
+--- !u!1 &1191800351
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1191800354}
+  - component: {fileID: 1191800353}
+  - component: {fileID: 1191800352}
+  m_Layer: 0
+  m_Name: Crappy Help Text
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!102 &1191800352
+TextMesh:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191800351}
+  m_Text: 'Controls:
+
+    - left mouse moves
+
+    - right mouse paints
+
+    - T selects
+    paint remover
+
+    - Y selects ground
+
+    - U selects path
+
+    - I selects
+    dirt
+
+    - O selects sand
+
+    - P saves
+
+    - L loads the latest save
+
+    -
+    Esc quits the game
+
+    - Home opens github
+
+    - End opens the docs'
+  m_OffsetZ: 0
+  m_CharacterSize: 0.35
+  m_LineSpacing: 1
+  m_Anchor: 0
+  m_Alignment: 0
+  m_TabSize: 4
+  m_FontSize: 0
+  m_FontStyle: 0
+  m_RichText: 1
+  m_Font: {fileID: 10102, guid: 0000000000000000e000000000000000, type: 0}
+  m_Color:
+    serializedVersion: 2
+    rgba: 4278242559
+--- !u!23 &1191800353
+MeshRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191800351}
+  m_Enabled: 1
+  m_CastShadows: 1
+  m_ReceiveShadows: 1
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 2
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10100, guid: 0000000000000000e000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 3
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_AdditionalVertexStreams: {fileID: 0}
+--- !u!4 &1191800354
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1191800351}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -5, y: 10, z: 0}
+  m_LocalScale: {x: 0.8, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &1989744807
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -248,7 +248,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 626258690}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 5, y: 5, z: -10}
+  m_LocalPosition: {x: 5.5, y: 5.5, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -479,7 +479,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1989744807}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.5, y: 0.5, z: 0}
+  m_LocalPosition: {x: 5.5, y: 5.5, z: 0}
   m_LocalScale: {x: 0.25, y: 0.25, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -155,7 +155,7 @@ MonoBehaviour:
   gridWorldSize_: {x: 11, y: 11, z: 0}
   nodeRadius_: 1
   player_: {fileID: 1989744811}
-  nodeVisual_: {fileID: 2098585260}
+  tilemapVisual_: {fileID: 2098585260}
 --- !u!4 &593590128
 Transform:
   m_ObjectHideFlags: 0
@@ -498,7 +498,7 @@ GameObject:
   - component: {fileID: 2098585263}
   - component: {fileID: 2098585262}
   m_Layer: 0
-  m_Name: NodeVisual
+  m_Name: TilemapVisual
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -513,7 +513,7 @@ MonoBehaviour:
   m_GameObject: {fileID: 2098585259}
   m_Enabled: 1
   m_EditorHideFlags: 0
-  m_Script: {fileID: 11500000, guid: 510f0267f7403407d88d7e99b10c503d, type: 3}
+  m_Script: {fileID: 11500000, guid: 73e6ef86219694b368b91b5016232253, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
   nodeSpriteUVArray_:

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -224,7 +224,7 @@ Camera:
   far clip plane: 1000
   field of view: 60
   orthographic: 1
-  orthographic size: 5
+  orthographic size: 6.5413175
   m_Depth: -1
   m_CullingMask:
     serializedVersion: 2

--- a/Assets/Scripts/Core/GameController.cs
+++ b/Assets/Scripts/Core/GameController.cs
@@ -109,6 +109,12 @@ namespace OperationBlackwell.Core {
 			if(Input.GetKeyDown(KeyCode.Escape)) {
 				Application.Quit(0);
 			}
+			if(Input.GetKeyDown(KeyCode.Home)) {
+				Application.OpenURL("https://github.com/Online-Pluisje-Art/Operation-Blackwell/tree/development");
+			}
+			if(Input.GetKeyDown(KeyCode.End)) {
+				Application.OpenURL("https://docs.opa.rip/");
+			}
 		}
 
 		/*

--- a/Assets/Scripts/Core/GameController.cs
+++ b/Assets/Scripts/Core/GameController.cs
@@ -14,15 +14,16 @@ namespace OperationBlackwell.Core {
 		public delegate void MoveEvent(Vector3 position);
 		public event MoveEvent Moved;
 
-		private Grid<Node.NodeObject> grid_;
-		private Node nodes_;
+		private Grid<Tilemap.Node> grid_;
+		private Tilemap tilemap_;
 
-		[SerializeField] private NodeVisual nodeVisual_;
-		private Node.NodeObject.NodeSprite nodeSprite_;
+		[SerializeField] private TilemapVisual tilemapVisual_;
+		private Tilemap.Node.NodeSprite nodeSprite_;
 		private void Start() {
-			nodes_ = new Node((int)gridWorldSize_.x, (int)gridWorldSize_.y, nodeRadius_);
-			grid_ = nodes_.GetGrid();
-			nodes_.SetNodeVisual(nodeVisual_);
+			grid_ = new Grid<Tilemap.Node>((int)gridWorldSize_.x, (int)gridWorldSize_.y, nodeRadius_, new Vector3(0, 0, 0), 
+				(Grid<Tilemap.Node> g, Vector3 worldPos, int x, int y) => new Tilemap.Node(worldPos, x, y, g, true, true, Tilemap.Node.CoverStatus.NONE));
+			tilemap_ = new Tilemap(grid_);
+			tilemap_.SetTilemapVisual(tilemapVisual_);
 			// Node unwalkableNode = grid_.NodeFromWorldPoint(new Vector3(0, 0, 2));
 			// unwalkableNode.walkable = false;
 		}
@@ -74,23 +75,23 @@ namespace OperationBlackwell.Core {
 		private void HandlePainting() {
 			// Tilemap code, rightclick please!
 			if(Input.GetKeyDown(KeyCode.T)) {
-				nodeSprite_ = Node.NodeObject.NodeSprite.NONE;
+				nodeSprite_ = Tilemap.Node.NodeSprite.NONE;
 			}
 			if(Input.GetKeyDown(KeyCode.Y)) {
-				nodeSprite_ = Node.NodeObject.NodeSprite.GROUND;
+				nodeSprite_ = Tilemap.Node.NodeSprite.GROUND;
 			}
 			if(Input.GetKeyDown(KeyCode.U)) {
-				nodeSprite_ = Node.NodeObject.NodeSprite.PATH;
+				nodeSprite_ = Tilemap.Node.NodeSprite.PATH;
 			}
 			if(Input.GetKeyDown(KeyCode.I)) {
-				nodeSprite_ = Node.NodeObject.NodeSprite.DIRT;
+				nodeSprite_ = Tilemap.Node.NodeSprite.DIRT;
 			}
 			if(Input.GetKeyDown(KeyCode.O)) {
-				nodeSprite_ = Node.NodeObject.NodeSprite.SAND;
+				nodeSprite_ = Tilemap.Node.NodeSprite.SAND;
 			}
 			if(Input.GetMouseButtonDown(1)) {
 				Vector3 mouseWorldPosition = Utils.GetMouseWorldPosition();
-				Node.NodeObject node = grid_.NodeFromWorldPoint(mouseWorldPosition);
+				Tilemap.Node node = grid_.NodeFromWorldPoint(mouseWorldPosition);
 				node.SetNodeSprite(nodeSprite_);
 				grid_.TriggerGridObjectChanged(node.gridX, node.gridY);
 			}
@@ -98,10 +99,10 @@ namespace OperationBlackwell.Core {
 
 		private void HandleSaveLoad() {
 			if(Input.GetKeyDown(KeyCode.P)) {
-				nodes_.Save();
+				tilemap_.Save();
 			}
 			if(Input.GetKeyDown(KeyCode.L)) {
-				nodes_.Load();
+				tilemap_.Load();
 			}
 		}
 
@@ -131,14 +132,14 @@ namespace OperationBlackwell.Core {
 				return false;
 			}
 
-			Node.NodeObject playerNode = grid_.GetGridObject(playerPosition);
-			Node.NodeObject targetNode = grid_.GetGridObject(targetPosition);
+			Tilemap.Node playerNode = grid_.GetGridObject(playerPosition);
+			Tilemap.Node targetNode = grid_.GetGridObject(targetPosition);
 
 			if(playerNode.worldPosition == targetNode.worldPosition) {
 				return false;
 			}
 			// We're moving, so we need to check if we can move.
-			List<Node.NodeObject> neighbours = grid_.GetNeighbours(playerNode);
+			List<Tilemap.Node> neighbours = grid_.GetNeighbours(playerNode);
 			if(neighbours.Contains(targetNode)) {
 				if(targetNode.walkable) {
 					movement = targetNode.worldPosition - playerNode.worldPosition;

--- a/Assets/Scripts/Core/GameController.cs
+++ b/Assets/Scripts/Core/GameController.cs
@@ -22,7 +22,7 @@ namespace OperationBlackwell.Core {
 		private void Start() {
 			nodes_ = new Node((int)gridWorldSize_.x, (int)gridWorldSize_.y, nodeRadius_);
 			grid_ = nodes_.GetGrid();
-			nodeVisual_.SetGrid(grid_);
+			nodes_.SetNodeVisual(nodeVisual_);
 			// Node unwalkableNode = grid_.NodeFromWorldPoint(new Vector3(0, 0, 2));
 			// unwalkableNode.walkable = false;
 		}
@@ -96,12 +96,12 @@ namespace OperationBlackwell.Core {
 		}
 
 		private void HandleSaveLoad() {
-			// if(Input.GetKeyDown(KeyCode.P)) {
-			// 	tilemap.Save();
-			// }
-			// if(Input.GetKeyDown(KeyCode.L)) {
-			// 	tilemap.Load();
-			// }
+			if(Input.GetKeyDown(KeyCode.P)) {
+				nodes_.Save();
+			}
+			if(Input.GetKeyDown(KeyCode.L)) {
+				nodes_.Load();
+			}
 		}
 
 		/*

--- a/Assets/Scripts/Core/GameController.cs
+++ b/Assets/Scripts/Core/GameController.cs
@@ -14,13 +14,14 @@ namespace OperationBlackwell.Core {
 		public delegate void MoveEvent(Vector3 position);
 		public event MoveEvent Moved;
 
-		private Grid<Node> grid_;
+		private Grid<Node.NodeObject> grid_;
+		private Node nodes_;
 
 		[SerializeField] private NodeVisual nodeVisual_;
-		private Node.NodeSprite nodeSprite_;
+		private Node.NodeObject.NodeSprite nodeSprite_;
 		private void Start() {
-			grid_ = new Grid<Node>((int)gridWorldSize_.x, (int)gridWorldSize_.y, nodeRadius_, new Vector3(0, 0, 0), 
-				(Grid<Node> g, Vector3 worldPos, int x, int y) => new Node(worldPos, x, y, g, true, true, Node.CoverStatus.NONE));
+			nodes_ = new Node((int)gridWorldSize_.x, (int)gridWorldSize_.y, nodeRadius_);
+			grid_ = nodes_.GetGrid();
 			nodeVisual_.SetGrid(grid_);
 			// Node unwalkableNode = grid_.NodeFromWorldPoint(new Vector3(0, 0, 2));
 			// unwalkableNode.walkable = false;
@@ -72,23 +73,23 @@ namespace OperationBlackwell.Core {
 		private void HandlePainting() {
 			// Tilemap code, rightclick please!
 			if(Input.GetKeyDown(KeyCode.T)) {
-				nodeSprite_ = Node.NodeSprite.NONE;
+				nodeSprite_ = Node.NodeObject.NodeSprite.NONE;
 			}
 			if(Input.GetKeyDown(KeyCode.Y)) {
-				nodeSprite_ = Node.NodeSprite.GROUND;
+				nodeSprite_ = Node.NodeObject.NodeSprite.GROUND;
 			}
 			if(Input.GetKeyDown(KeyCode.U)) {
-				nodeSprite_ = Node.NodeSprite.PATH;
+				nodeSprite_ = Node.NodeObject.NodeSprite.PATH;
 			}
 			if(Input.GetKeyDown(KeyCode.I)) {
-				nodeSprite_ = Node.NodeSprite.DIRT;
+				nodeSprite_ = Node.NodeObject.NodeSprite.DIRT;
 			}
 			if(Input.GetKeyDown(KeyCode.O)) {
-				nodeSprite_ = Node.NodeSprite.SAND;
+				nodeSprite_ = Node.NodeObject.NodeSprite.SAND;
 			}
 			if(Input.GetMouseButtonDown(1)) {
 				Vector3 mouseWorldPosition = Utils.GetMouseWorldPosition();
-				Node node = grid_.NodeFromWorldPoint(mouseWorldPosition);
+				Node.NodeObject node = grid_.NodeFromWorldPoint(mouseWorldPosition);
 				node.SetNodeSprite(nodeSprite_);
 				grid_.TriggerGridObjectChanged(node.gridX, node.gridY);
 			}
@@ -117,14 +118,14 @@ namespace OperationBlackwell.Core {
 				return false;
 			}
 
-			Node playerNode = grid_.NodeFromWorldPoint(playerPosition);
-			Node targetNode = grid_.NodeFromWorldPoint(targetPosition);
+			Node.NodeObject playerNode = grid_.GetGridObject(playerPosition);
+			Node.NodeObject targetNode = grid_.GetGridObject(targetPosition);
 
 			if(playerNode.worldPosition == targetNode.worldPosition) {
 				return false;
 			}
 			// We're moving, so we need to check if we can move.
-			List<Node> neighbours = grid_.GetNeighbours(playerNode);
+			List<Node.NodeObject> neighbours = grid_.GetNeighbours(playerNode);
 			if(neighbours.Contains(targetNode)) {
 				if(targetNode.walkable) {
 					movement = targetNode.worldPosition - playerNode.worldPosition;

--- a/Assets/Scripts/Core/GameController.cs
+++ b/Assets/Scripts/Core/GameController.cs
@@ -31,6 +31,7 @@ namespace OperationBlackwell.Core {
 			HandleMovement();
 			HandlePainting();
 			HandleSaveLoad();
+			HandleMisc();
 		}
 
 		private void HandleMovement() {
@@ -101,6 +102,12 @@ namespace OperationBlackwell.Core {
 			}
 			if(Input.GetKeyDown(KeyCode.L)) {
 				nodes_.Load();
+			}
+		}
+
+		private void HandleMisc() {
+			if(Input.GetKeyDown(KeyCode.Escape)) {
+				Application.Quit(0);
 			}
 		}
 

--- a/Assets/Scripts/Core/Grid.cs
+++ b/Assets/Scripts/Core/Grid.cs
@@ -110,5 +110,34 @@ namespace OperationBlackwell.Core {
 				OnGridObjectChanged(this, new OnGridObjectChangedEventArgs { x = x, y = y });
 			}
 		}
+
+		public void SetGridObject(int x, int y, TGridObject value) {
+			if(x >= 0 && y >= 0 && x < gridSizeX && y < gridSizeY) {
+				gridArray_[x, y] = value;
+				if (OnGridObjectChanged != null) {
+					OnGridObjectChanged(this, new OnGridObjectChangedEventArgs { x = x, y = y });
+				}
+			}
+		}
+
+		public void SetGridObject(Vector3 worldPosition, TGridObject value) {
+			int x, y;
+			GetXY(worldPosition, out x, out y);
+			SetGridObject(x, y, value);
+		}
+
+		public TGridObject GetGridObject(int x, int y) {
+			if(x >= 0 && y >= 0 && x < gridSizeX && y < gridSizeY) {
+				return gridArray_[x, y];
+			} else {
+				return default(TGridObject);
+			}
+		}
+
+		public TGridObject GetGridObject(Vector3 worldPosition) {
+			int x, y;
+			GetXY(worldPosition, out x, out y);
+			return GetGridObject(x, y);
+		}
 	}
 }

--- a/Assets/Scripts/Core/MapEditorSaveSystem.cs
+++ b/Assets/Scripts/Core/MapEditorSaveSystem.cs
@@ -1,0 +1,109 @@
+using System.IO;
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace OperationBlackwell.Core {
+	public static class SaveSystem {
+
+		private const string SAVE_EXTENSION = "txt";
+
+		private static readonly string SAVE_FOLDER = Application.dataPath + "/SavesWorld/";
+		private static bool isInit = false;
+
+		public static void Init() {
+			if(!isInit) {
+				isInit = true;
+				// Test if Save Folder exists.
+				if(!Directory.Exists(SAVE_FOLDER)) {
+					// Create Save Folder.
+					Directory.CreateDirectory(SAVE_FOLDER);
+				}
+			}
+		}
+
+		public static void Save(string fileName, string saveString, bool overwrite) {
+			Init();
+			string saveFileName = fileName;
+			if(!overwrite) {
+				// Make sure the Save Number is unique so it doesnt overwrite a previous save file.
+				int saveNumber = 1;
+				while(File.Exists(SAVE_FOLDER + saveFileName + "." + SAVE_EXTENSION)) {
+					saveNumber++;
+					saveFileName = fileName + "_" + saveNumber;
+				}
+				// saveFileName is unique.
+			}
+			File.WriteAllText(SAVE_FOLDER + saveFileName + "." + SAVE_EXTENSION, saveString);
+		}
+
+		public static string Load(string fileName) {
+			Init();
+			if(File.Exists(SAVE_FOLDER + fileName + "." + SAVE_EXTENSION)) {
+				string saveString = File.ReadAllText(SAVE_FOLDER + fileName + "." + SAVE_EXTENSION);
+				return saveString;
+			} else {
+				return null;
+			}
+		}
+
+		public static string LoadMostRecentFile() {
+			Init();
+			DirectoryInfo directoryInfo = new DirectoryInfo(SAVE_FOLDER);
+			// Get all the save files.
+			FileInfo[] saveFiles = directoryInfo.GetFiles("*." + SAVE_EXTENSION);
+			// Cycle through all save files and identify the most recent one.
+			FileInfo mostRecentFile = null;
+			foreach(FileInfo fileInfo in saveFiles) {
+				if(mostRecentFile == null) {
+					mostRecentFile = fileInfo;
+				} else {
+					if(fileInfo.LastWriteTime > mostRecentFile.LastWriteTime) {
+						mostRecentFile = fileInfo;
+					}
+				}
+			}
+
+			// If theres a save file, load it, if not return null.
+			if(mostRecentFile != null) {
+				string saveString = File.ReadAllText(mostRecentFile.FullName);
+				return saveString;
+			} else {
+				return null;
+			}
+		}
+
+		public static void SaveObject(object saveObject) {
+			SaveObject("save", saveObject, false);
+		}
+
+		public static void SaveObject(string fileName, object saveObject, bool overwrite) {
+			Init();
+			string json = JsonUtility.ToJson(saveObject);
+			Save(fileName, json, overwrite);
+		}
+
+		public static TSaveObject LoadMostRecentObject<TSaveObject>() {
+			Init();
+			string saveString = LoadMostRecentFile();
+			if(saveString != null) {
+				TSaveObject saveObject = JsonUtility.FromJson<TSaveObject>(saveString);
+				return saveObject;
+			} else {
+				return default(TSaveObject);
+			}
+		}
+
+		public static TSaveObject LoadObject<TSaveObject>(string fileName) {
+			Init();
+			string saveString = Load(fileName);
+			if(saveString != null) {
+				TSaveObject saveObject = JsonUtility.FromJson<TSaveObject>(saveString);
+				return saveObject;
+			} else {
+				return default(TSaveObject);
+			}
+		}
+
+	}
+}

--- a/Assets/Scripts/Core/MapEditorSaveSystem.cs.meta
+++ b/Assets/Scripts/Core/MapEditorSaveSystem.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 99193d835b45209148d2120580a4b7ae
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Core/Node.cs
+++ b/Assets/Scripts/Core/Node.cs
@@ -34,6 +34,10 @@ namespace OperationBlackwell.Core {
 			}
 		}
 
+		public void SetNodeVisual(NodeVisual nodeVisual) {
+			nodeVisual.SetGrid(this, grid_);
+		}
+
 		public class SaveObject {
 			public NodeObject.SaveObject[] nodeObjectSaveObjectArray;
 		}

--- a/Assets/Scripts/Core/Node.cs
+++ b/Assets/Scripts/Core/Node.cs
@@ -4,31 +4,9 @@ using UnityEngine;
 
 namespace OperationBlackwell.Core {
 	public class Node {
-		public enum CoverStatus {
-			NONE,
-			HALF,
-			FULL,
-		}
+		public event System.EventHandler OnLoaded;
 
-		public enum NodeSprite {
-			NONE,
-			GROUND,
-			PATH,
-			DIRT,
-			SAND,
-		}
-		// Holds the amount of cover this tile gives.
-		public CoverStatus cover {get; private set;}
-		// Holds if the tile can be walked over.
-		public bool walkable; // {get; protected set;}
-		// Holds if the tile can be shot through.
-		public bool shootable {get; private set;}
-		public Vector3 worldPosition {get; private set;}
-		public int gridX {get; private set;}
-		public int gridY {get; private set;}
-		private NodeSprite nodeSprite_;
-
-		private Grid<Node> grid_;
+		private Grid<NodeObject> grid_;
 		// public int gCost;
 		// public int hCost;
 
@@ -40,27 +18,119 @@ namespace OperationBlackwell.Core {
 
 		// public Node parent;
 
-		public Node(Vector3 worldPosition, int gridX, int gridY, Grid<Node> grid, bool walkable, bool shootable, CoverStatus cover) {
-			this.worldPosition = worldPosition;
-			this.gridX = gridX;
-			this.gridY = gridY;
-			this.grid_ = grid;
-			this.walkable = walkable;
-			this.shootable = shootable;
-			this.cover = cover;
+		public Node(int width, int height, float nodeRadius) {
+			grid_ = new Grid<NodeObject>(width, height, nodeRadius, new Vector3(0, 0, 0), 
+				(Grid<NodeObject> g, Vector3 worldPos, int x, int y) => new NodeObject(worldPos, x, y, g, true, true, Node.NodeObject.CoverStatus.NONE));
 		}
 
-		public void SetNodeSprite(NodeSprite nodeSprite) {
-			this.nodeSprite_ = nodeSprite;
-			// grid_.TriggerGridObjectChanged(gridX, gridY);
+		public Grid<NodeObject> GetGrid() {
+			return grid_;
 		}
 
-		public NodeSprite GetNodeSprite() {
-			return nodeSprite_;
+		public void SetNodeSprite(Vector3 worldPosition, NodeObject.NodeSprite nodeSprite) {
+			NodeObject nodeObject = grid_.GetGridObject(worldPosition);
+			if(nodeObject != null) {
+				nodeObject.SetNodeSprite(nodeSprite);
+			}
 		}
 
-		public override string ToString() {
-			return nodeSprite_.ToString();
+		public class SaveObject {
+			public NodeObject.SaveObject[] nodeObjectSaveObjectArray;
+		}
+	
+		public void Save() {
+			List<NodeObject.SaveObject> nodeSaveObjectList = new List<NodeObject.SaveObject>();
+			for(int x = 0; x < grid_.gridSizeX; x++) {
+				for(int y = 0; y < grid_.gridSizeY; y++) {
+					NodeObject nodeObject = grid_.NodeFromWorldPoint(grid_.GetWorldPosition(x, y));
+					nodeSaveObjectList.Add(nodeObject.Save());
+				}
+			}
+
+			SaveObject saveObject = new SaveObject { nodeObjectSaveObjectArray = nodeSaveObjectList.ToArray() };
+			SaveSystem.SaveObject(saveObject);
+		}
+
+		public void Load() {
+			SaveObject saveObject = SaveSystem.LoadMostRecentObject<SaveObject>();
+			foreach(NodeObject.SaveObject nodeObjectSaveObject in saveObject.nodeObjectSaveObjectArray) {				
+				NodeObject nodeObject = grid_.GetGridObject(nodeObjectSaveObject.x, nodeObjectSaveObject.y);
+				nodeObject.Load(nodeObjectSaveObject);
+			}
+			OnLoaded?.Invoke(this, System.EventArgs.Empty);
+		}
+
+		public class NodeObject {
+
+			public enum CoverStatus {
+				NONE,
+				HALF,
+				FULL,
+			}
+
+			public enum NodeSprite {
+				NONE,
+				GROUND,
+				PATH,
+				DIRT,
+				SAND,
+			}
+			// Holds the amount of cover this tile gives.
+			public CoverStatus cover {get; private set;}
+			// Holds if the tile can be walked over.
+			public bool walkable; // {get; protected set;}
+			// Holds if the tile can be shot through.
+			public bool shootable {get; private set;}
+			public Vector3 worldPosition {get; private set;}
+			public int gridX {get; private set;}
+			public int gridY {get; private set;}
+			private NodeSprite nodeSprite_;
+
+			private Grid<NodeObject> grid_;
+
+			public NodeObject(Vector3 worldPosition, int gridX, int gridY, Grid<NodeObject> grid, bool walkable, bool shootable, CoverStatus cover) {
+				this.worldPosition = worldPosition;
+				this.gridX = gridX;
+				this.gridY = gridY;
+				this.grid_ = grid;
+				this.walkable = walkable;
+				this.shootable = shootable;
+				this.cover = cover;
+			}
+			[System.Serializable]
+			public class SaveObject {
+				public NodeSprite nodeSprite;
+				public int x;
+				public int y;
+			}
+
+			/*
+			* Save - Load
+			* */
+			public SaveObject Save() {
+				return new SaveObject { 
+					nodeSprite = this.nodeSprite_,
+					x = this.gridX,
+					y = this.gridY,
+				};
+			}
+
+			public void Load(SaveObject saveObject) {
+				this.nodeSprite_ = saveObject.nodeSprite;
+			}
+
+			public NodeSprite GetNodeSprite() {
+				return nodeSprite_;
+			}
+
+			public override string ToString() {
+				return nodeSprite_.ToString();
+			}
+
+			public void SetNodeSprite(NodeSprite nodeSprite) {
+				this.nodeSprite_ = nodeSprite;
+				grid_.TriggerGridObjectChanged(gridX, gridY);
+			}
 		}
 	}
 }

--- a/Assets/Scripts/Core/NodeVisual.cs
+++ b/Assets/Scripts/Core/NodeVisual.cs
@@ -42,15 +42,19 @@ namespace OperationBlackwell.Core {
 			}
 		}
 
-		public void SetGrid(Grid<Node.NodeObject> grid) {
+		public void SetGrid(Node node, Grid<Node.NodeObject> grid) {
 			this.grid_ = grid;
 			UpdateNodeVisual();
 
 			grid_.OnGridObjectChanged += Grid_OnGridValueChanged;
-			// tilemap.OnLoaded += Tilemap_OnLoaded;
+			node.OnLoaded += NodeVisual_OnLoaded;
 		}
 
 		private void Grid_OnGridValueChanged(object sender, Grid<Node.NodeObject>.OnGridObjectChangedEventArgs e) {
+			updateMesh_ = true;
+		}
+
+		private void NodeVisual_OnLoaded(object sender, System.EventArgs e) {
 			updateMesh_ = true;
 		}
 

--- a/Assets/Scripts/Core/NodeVisual.cs
+++ b/Assets/Scripts/Core/NodeVisual.cs
@@ -7,7 +7,7 @@ namespace OperationBlackwell.Core {
 
 		[System.Serializable]
 		public struct NodeSpriteUV {
-			public Node.NodeSprite nodeSprite;
+			public Node.NodeObject.NodeSprite nodeSprite;
 			public Vector2Int uv00Pixels;
 			public Vector2Int uv11Pixels;
 		}
@@ -17,12 +17,12 @@ namespace OperationBlackwell.Core {
 			public Vector2 uv11;
 		}
 		
-		private Grid<Node> grid_;
+		private Grid<Node.NodeObject> grid_;
 		private Mesh mesh_;
 		private bool updateMesh_;
 
 		[SerializeField] private NodeSpriteUV[] nodeSpriteUVArray_;
-		private Dictionary<Node.NodeSprite, UVCoords> uvCoordsDictionary_;
+		private Dictionary<Node.NodeObject.NodeSprite, UVCoords> uvCoordsDictionary_;
 
 		private void Awake() {
 			mesh_ = new Mesh();
@@ -32,9 +32,9 @@ namespace OperationBlackwell.Core {
 			float textureWidth = texture.width;
 			float textureHeight = texture.height;
 
-			uvCoordsDictionary_ = new Dictionary<Node.NodeSprite, UVCoords>();
+			uvCoordsDictionary_ = new Dictionary<Node.NodeObject.NodeSprite, UVCoords>();
 
-			foreach (NodeSpriteUV nodeSpriteUV in nodeSpriteUVArray_) {
+			foreach(NodeSpriteUV nodeSpriteUV in nodeSpriteUVArray_) {
 				uvCoordsDictionary_[nodeSpriteUV.nodeSprite] = new UVCoords {
 					uv00 = new Vector2(nodeSpriteUV.uv00Pixels.x / textureWidth, nodeSpriteUV.uv00Pixels.y / textureHeight),
 					uv11 = new Vector2(nodeSpriteUV.uv11Pixels.x / textureWidth, nodeSpriteUV.uv11Pixels.y / textureHeight),
@@ -42,7 +42,7 @@ namespace OperationBlackwell.Core {
 			}
 		}
 
-		public void SetGrid(Grid<Node> grid) {
+		public void SetGrid(Grid<Node.NodeObject> grid) {
 			this.grid_ = grid;
 			UpdateNodeVisual();
 
@@ -50,7 +50,7 @@ namespace OperationBlackwell.Core {
 			// tilemap.OnLoaded += Tilemap_OnLoaded;
 		}
 
-		private void Grid_OnGridValueChanged(object sender, Grid<Node>.OnGridObjectChangedEventArgs e) {
+		private void Grid_OnGridValueChanged(object sender, Grid<Node.NodeObject>.OnGridObjectChangedEventArgs e) {
 			updateMesh_ = true;
 		}
 
@@ -69,12 +69,12 @@ namespace OperationBlackwell.Core {
 					int index = x * grid_.gridSizeY + y;
 					Vector3 quadSize = new Vector3(1, 1) * grid_.cellSize;
 
-					Node node;
+					Node.NodeObject node;
 					Vector3 worldPosition = grid_.GetWorldPosition(x, y);
-					node = grid_.NodeFromWorldPoint(worldPosition);
-					Node.NodeSprite nodeSprite = node.GetNodeSprite();
+					node = grid_.GetGridObject(worldPosition);
+					Node.NodeObject.NodeSprite nodeSprite = node.GetNodeSprite();
 					Vector2 gridUV00, gridUV11;
-					if (nodeSprite == Node.NodeSprite.NONE) {
+					if (nodeSprite == Node.NodeObject.NodeSprite.NONE) {
 						gridUV00 = Vector2.zero;
 						gridUV11 = Vector2.zero;
 						quadSize = Vector3.zero;

--- a/Assets/Scripts/Core/Tilemap.cs
+++ b/Assets/Scripts/Core/Tilemap.cs
@@ -3,10 +3,10 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace OperationBlackwell.Core {
-	public class Node {
+	public class Tilemap {
 		public event System.EventHandler OnLoaded;
 
-		private Grid<NodeObject> grid_;
+		private Grid<Node> grid_;
 		// public int gCost;
 		// public int hCost;
 
@@ -18,53 +18,52 @@ namespace OperationBlackwell.Core {
 
 		// public Node parent;
 
-		public Node(int width, int height, float nodeRadius) {
-			grid_ = new Grid<NodeObject>(width, height, nodeRadius, new Vector3(0, 0, 0), 
-				(Grid<NodeObject> g, Vector3 worldPos, int x, int y) => new NodeObject(worldPos, x, y, g, true, true, Node.NodeObject.CoverStatus.NONE));
+		public Tilemap(Grid<Node> grid) {
+			this.grid_ = grid;
 		}
 
-		public Grid<NodeObject> GetGrid() {
+		public Grid<Node> GetGrid() {
 			return grid_;
 		}
 
-		public void SetNodeSprite(Vector3 worldPosition, NodeObject.NodeSprite nodeSprite) {
-			NodeObject nodeObject = grid_.GetGridObject(worldPosition);
-			if(nodeObject != null) {
-				nodeObject.SetNodeSprite(nodeSprite);
+		public void SetNodeSprite(Vector3 worldPosition, Node.NodeSprite nodeSprite) {
+			Node node = grid_.GetGridObject(worldPosition);
+			if(node != null) {
+				node.SetNodeSprite(nodeSprite);
 			}
 		}
 
-		public void SetNodeVisual(NodeVisual nodeVisual) {
-			nodeVisual.SetGrid(this, grid_);
+		public void SetTilemapVisual(TilemapVisual tilemapVisual) {
+			tilemapVisual.SetGrid(this, grid_);
 		}
 
 		public class SaveObject {
-			public NodeObject.SaveObject[] nodeObjectSaveObjectArray;
+			public Node.SaveObject[] nodeSaveObjectArray;
 		}
 	
 		public void Save() {
-			List<NodeObject.SaveObject> nodeSaveObjectList = new List<NodeObject.SaveObject>();
+			List<Node.SaveObject> nodeSaveObjectList = new List<Node.SaveObject>();
 			for(int x = 0; x < grid_.gridSizeX; x++) {
 				for(int y = 0; y < grid_.gridSizeY; y++) {
-					NodeObject nodeObject = grid_.NodeFromWorldPoint(grid_.GetWorldPosition(x, y));
-					nodeSaveObjectList.Add(nodeObject.Save());
+					Node node = grid_.GetGridObject(x, y);
+					nodeSaveObjectList.Add(node.Save());
 				}
 			}
 
-			SaveObject saveObject = new SaveObject { nodeObjectSaveObjectArray = nodeSaveObjectList.ToArray() };
+			SaveObject saveObject = new SaveObject { nodeSaveObjectArray = nodeSaveObjectList.ToArray() };
 			SaveSystem.SaveObject(saveObject);
 		}
 
 		public void Load() {
 			SaveObject saveObject = SaveSystem.LoadMostRecentObject<SaveObject>();
-			foreach(NodeObject.SaveObject nodeObjectSaveObject in saveObject.nodeObjectSaveObjectArray) {				
-				NodeObject nodeObject = grid_.GetGridObject(nodeObjectSaveObject.x, nodeObjectSaveObject.y);
-				nodeObject.Load(nodeObjectSaveObject);
+			foreach(Node.SaveObject nodeSaveObject in saveObject.nodeSaveObjectArray) {				
+				Node node = grid_.GetGridObject(nodeSaveObject.x, nodeSaveObject.y);
+				node.Load(nodeSaveObject);
 			}
 			OnLoaded?.Invoke(this, System.EventArgs.Empty);
 		}
 
-		public class NodeObject {
+		public class Node {
 
 			public enum CoverStatus {
 				NONE,
@@ -90,9 +89,9 @@ namespace OperationBlackwell.Core {
 			public int gridY {get; private set;}
 			private NodeSprite nodeSprite_;
 
-			private Grid<NodeObject> grid_;
+			private Grid<Node> grid_;
 
-			public NodeObject(Vector3 worldPosition, int gridX, int gridY, Grid<NodeObject> grid, bool walkable, bool shootable, CoverStatus cover) {
+			public Node(Vector3 worldPosition, int gridX, int gridY, Grid<Node> grid, bool walkable, bool shootable, CoverStatus cover) {
 				this.worldPosition = worldPosition;
 				this.gridX = gridX;
 				this.gridY = gridY;

--- a/Assets/Scripts/Core/Tilemap.cs.meta
+++ b/Assets/Scripts/Core/Tilemap.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: 510f0267f7403407d88d7e99b10c503d
+guid: 1498fd3c650fec5728c31a0820ef853d
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/Assets/Scripts/Core/TilemapVisual.cs
+++ b/Assets/Scripts/Core/TilemapVisual.cs
@@ -3,11 +3,11 @@ using System.Collections.Generic;
 using UnityEngine;
 
 namespace OperationBlackwell.Core {
-	public class NodeVisual : MonoBehaviour {
+	public class TilemapVisual : MonoBehaviour {
 
 		[System.Serializable]
 		public struct NodeSpriteUV {
-			public Node.NodeObject.NodeSprite nodeSprite;
+			public Tilemap.Node.NodeSprite nodeSprite;
 			public Vector2Int uv00Pixels;
 			public Vector2Int uv11Pixels;
 		}
@@ -17,12 +17,12 @@ namespace OperationBlackwell.Core {
 			public Vector2 uv11;
 		}
 		
-		private Grid<Node.NodeObject> grid_;
+		private Grid<Tilemap.Node> grid_;
 		private Mesh mesh_;
 		private bool updateMesh_;
 
 		[SerializeField] private NodeSpriteUV[] nodeSpriteUVArray_;
-		private Dictionary<Node.NodeObject.NodeSprite, UVCoords> uvCoordsDictionary_;
+		private Dictionary<Tilemap.Node.NodeSprite, UVCoords> uvCoordsDictionary_;
 
 		private void Awake() {
 			mesh_ = new Mesh();
@@ -32,7 +32,7 @@ namespace OperationBlackwell.Core {
 			float textureWidth = texture.width;
 			float textureHeight = texture.height;
 
-			uvCoordsDictionary_ = new Dictionary<Node.NodeObject.NodeSprite, UVCoords>();
+			uvCoordsDictionary_ = new Dictionary<Tilemap.Node.NodeSprite, UVCoords>();
 
 			foreach(NodeSpriteUV nodeSpriteUV in nodeSpriteUVArray_) {
 				uvCoordsDictionary_[nodeSpriteUV.nodeSprite] = new UVCoords {
@@ -42,19 +42,19 @@ namespace OperationBlackwell.Core {
 			}
 		}
 
-		public void SetGrid(Node node, Grid<Node.NodeObject> grid) {
+		public void SetGrid(Tilemap tilemap, Grid<Tilemap.Node> grid) {
 			this.grid_ = grid;
 			UpdateNodeVisual();
 
 			grid_.OnGridObjectChanged += Grid_OnGridValueChanged;
-			node.OnLoaded += NodeVisual_OnLoaded;
+			tilemap.OnLoaded += TilemapVisual_OnLoaded;
 		}
 
-		private void Grid_OnGridValueChanged(object sender, Grid<Node.NodeObject>.OnGridObjectChangedEventArgs e) {
+		private void Grid_OnGridValueChanged(object sender, Grid<Tilemap.Node>.OnGridObjectChangedEventArgs e) {
 			updateMesh_ = true;
 		}
 
-		private void NodeVisual_OnLoaded(object sender, System.EventArgs e) {
+		private void TilemapVisual_OnLoaded(object sender, System.EventArgs e) {
 			updateMesh_ = true;
 		}
 
@@ -73,12 +73,12 @@ namespace OperationBlackwell.Core {
 					int index = x * grid_.gridSizeY + y;
 					Vector3 quadSize = new Vector3(1, 1) * grid_.cellSize;
 
-					Node.NodeObject node;
+					Tilemap.Node node;
 					Vector3 worldPosition = grid_.GetWorldPosition(x, y);
 					node = grid_.GetGridObject(worldPosition);
-					Node.NodeObject.NodeSprite nodeSprite = node.GetNodeSprite();
+					Tilemap.Node.NodeSprite nodeSprite = node.GetNodeSprite();
 					Vector2 gridUV00, gridUV11;
-					if (nodeSprite == Node.NodeObject.NodeSprite.NONE) {
+					if (nodeSprite == Tilemap.Node.NodeSprite.NONE) {
 						gridUV00 = Vector2.zero;
 						gridUV11 = Vector2.zero;
 						quadSize = Vector3.zero;

--- a/Assets/Scripts/Core/TilemapVisual.cs.meta
+++ b/Assets/Scripts/Core/TilemapVisual.cs.meta
@@ -1,5 +1,5 @@
 fileFormatVersion: 2
-guid: b91a57601371cd6e5a7b4fc494be2fdd
+guid: 73e6ef86219694b368b91b5016232253
 MonoImporter:
   externalObjects: {}
   serializedVersion: 2

--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.1 Codename Longhorn
+  bundleVersion: 0.1 "Merope"
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
This PR adds more fancy grid features, starting with the map save/load system. This required a refactoring of how we spawn our grids, we now spawn a grid of NodeObjects. The saving and loading is really basic, and saves as `save_<number>.txt` where number is either non existent (first save) or increasing from 2 (if the file already exists). Work to improve that is ongoing. Furthermore, this PR implements escape to exit, home to open this github repo, end to open the documentation and adds control instructions as a sort sidebar. Lastly, some small fixes related to the gitignore, camera sizes, versioning and player spawn location can be found.

All in all, massive work on OPA-66 and early work on a kind of main menu (OPA-68). Work is ongoing to add actual tile states, so that a wall is actually unwalkable.