### PR TITLE
Add more tiledata to the storage

### DIFF
--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -302,25 +302,26 @@ TextMesh:
     - T selects
     paint remover
 
-    - Y selects ground
+    - Y selects pit tile
 
-    - U selects path
+    - U selects floor tile
 
-    - I selects
-    dirt
+    - I
+    selects wall tile
 
-    - O selects sand
+    - O selects cover tile
 
     - P saves
 
-    - L loads the latest save
+    - L loads the
+    latest save
 
-    -
-    Esc quits the game
+    - Esc quits the game
 
     - Home opens github
 
-    - End opens the docs'
+    - End opens
+    the docs'
   m_OffsetZ: 0
   m_CharacterSize: 0.35
   m_LineSpacing: 1

--- a/Assets/Scripts/Core/GameController.cs
+++ b/Assets/Scripts/Core/GameController.cs
@@ -21,7 +21,7 @@ namespace OperationBlackwell.Core {
 		private Tilemap.Node.NodeSprite nodeSprite_;
 		private void Start() {
 			grid_ = new Grid<Tilemap.Node>((int)gridWorldSize_.x, (int)gridWorldSize_.y, nodeRadius_, new Vector3(0, 0, 0), 
-				(Grid<Tilemap.Node> g, Vector3 worldPos, int x, int y) => new Tilemap.Node(worldPos, x, y, g, true, true, Tilemap.Node.CoverStatus.NONE));
+				(Grid<Tilemap.Node> g, Vector3 worldPos, int x, int y) => new Tilemap.Node(worldPos, x, y, g, true, true, false));
 			tilemap_ = new Tilemap(grid_);
 			tilemap_.SetTilemapVisual(tilemapVisual_);
 			// Node unwalkableNode = grid_.NodeFromWorldPoint(new Vector3(0, 0, 2));
@@ -78,16 +78,16 @@ namespace OperationBlackwell.Core {
 				nodeSprite_ = Tilemap.Node.NodeSprite.NONE;
 			}
 			if(Input.GetKeyDown(KeyCode.Y)) {
-				nodeSprite_ = Tilemap.Node.NodeSprite.GROUND;
+				nodeSprite_ = Tilemap.Node.NodeSprite.PIT;
 			}
 			if(Input.GetKeyDown(KeyCode.U)) {
-				nodeSprite_ = Tilemap.Node.NodeSprite.PATH;
+				nodeSprite_ = Tilemap.Node.NodeSprite.FLOOR;
 			}
 			if(Input.GetKeyDown(KeyCode.I)) {
-				nodeSprite_ = Tilemap.Node.NodeSprite.DIRT;
+				nodeSprite_ = Tilemap.Node.NodeSprite.WALL;
 			}
 			if(Input.GetKeyDown(KeyCode.O)) {
-				nodeSprite_ = Tilemap.Node.NodeSprite.SAND;
+				nodeSprite_ = Tilemap.Node.NodeSprite.COVER;
 			}
 			if(Input.GetMouseButtonDown(1)) {
 				Vector3 mouseWorldPosition = Utils.GetMouseWorldPosition();

--- a/Assets/Scripts/Core/Tilemap.cs
+++ b/Assets/Scripts/Core/Tilemap.cs
@@ -64,22 +64,16 @@ namespace OperationBlackwell.Core {
 		}
 
 		public class Node {
-
-			public enum CoverStatus {
-				NONE,
-				HALF,
-				FULL,
-			}
-
 			public enum NodeSprite {
+				// Default sprite.
 				NONE,
-				GROUND,
-				PATH,
-				DIRT,
-				SAND,
+				PIT,
+				FLOOR,
+				WALL,
+				COVER,
 			}
 			// Holds the amount of cover this tile gives.
-			public CoverStatus cover {get; private set;}
+			public bool cover {get; private set;}
 			// Holds if the tile can be walked over.
 			public bool walkable; // {get; protected set;}
 			// Holds if the tile can be shot through.
@@ -91,7 +85,7 @@ namespace OperationBlackwell.Core {
 
 			private Grid<Node> grid_;
 
-			public Node(Vector3 worldPosition, int gridX, int gridY, Grid<Node> grid, bool walkable, bool shootable, CoverStatus cover) {
+			public Node(Vector3 worldPosition, int gridX, int gridY, Grid<Node> grid, bool walkable, bool shootable, bool cover) {
 				this.worldPosition = worldPosition;
 				this.gridX = gridX;
 				this.gridY = gridY;
@@ -100,11 +94,15 @@ namespace OperationBlackwell.Core {
 				this.shootable = shootable;
 				this.cover = cover;
 			}
+
 			[System.Serializable]
 			public class SaveObject {
 				public NodeSprite nodeSprite;
 				public int x;
 				public int y;
+				public bool walkable;
+				public bool shootable;
+				public bool cover;
 			}
 
 			/*
@@ -115,11 +113,17 @@ namespace OperationBlackwell.Core {
 					nodeSprite = this.nodeSprite_,
 					x = this.gridX,
 					y = this.gridY,
+					walkable = this.walkable,
+					shootable = this.shootable,
+					cover = this.cover,
 				};
 			}
 
 			public void Load(SaveObject saveObject) {
 				this.nodeSprite_ = saveObject.nodeSprite;
+				this.walkable = saveObject.walkable;
+				this.shootable = saveObject.shootable;
+				this.cover = saveObject.cover;
 			}
 
 			public NodeSprite GetNodeSprite() {
@@ -132,6 +136,29 @@ namespace OperationBlackwell.Core {
 
 			public void SetNodeSprite(NodeSprite nodeSprite) {
 				this.nodeSprite_ = nodeSprite;
+				if(nodeSprite == NodeSprite.NONE) {
+					// Should be error state!
+					Debug.Log("NodeSprite none will become an hard error in the future!");
+					this.walkable = true;
+					this.shootable = true;
+					this.cover = false;
+				} else if(nodeSprite == NodeSprite.PIT) {
+					this.walkable = false;
+					this.shootable = true;
+					this.cover = false;
+				} else if(nodeSprite == NodeSprite.FLOOR) {
+					this.walkable = true;
+					this.shootable = true;
+					this.cover = false;
+				} else if(nodeSprite == NodeSprite.WALL) {
+					this.walkable = false;
+					this.shootable = false;
+					this.cover = false;
+				} else if(nodeSprite == NodeSprite.COVER) {
+					this.walkable = false;
+					this.shootable = true;
+					this.cover = true;
+				}
 				grid_.TriggerGridObjectChanged(gridX, gridY);
 			}
 		}


### PR DESCRIPTION
This PR puts more work to OPA-66, storing some more data in the save file and actually setting said data to the correct values when a new kind of tile is painted on the grid. Further improvements that remain to be done are mostly related to the saving system, which is what I'll work on next.