### PR TITLE
Unwalkable nodes

### DIFF
--- a/Assets/Resources/Materials/MovementTilemap.mat
+++ b/Assets/Resources/Materials/MovementTilemap.mat
@@ -8,8 +8,7 @@ Material:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: MovementTilemap
-  m_Shader: {fileID: -6465566751694194690, guid: 15408cf96e238d74e9d6e0679fa34b00,
-    type: 3}
+  m_Shader: {fileID: 10708, guid: 0000000000000000f000000000000000, type: 0}
   m_ShaderKeywords: 
   m_LightmapFlags: 4
   m_EnableInstancingVariants: 0
@@ -20,30 +19,10 @@ Material:
   m_SavedProperties:
     serializedVersion: 3
     m_TexEnvs:
-    - _AlphaTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _EmissionTex:
-        m_Texture: {fileID: 2800000, guid: 2b3abf7ef2dd23a409ce2e0b588d589c, type: 3}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
     - _MainTex:
-        m_Texture: {fileID: 2800000, guid: 2b3abf7ef2dd23a409ce2e0b588d589c, type: 3}
+        m_Texture: {fileID: 2800000, guid: 450691e1bc1f068af9fe1f1d04982b45, type: 3}
         m_Scale: {x: 1, y: 1}
         m_Offset: {x: 0, y: 0}
-    - _MaskTex:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    - _NormalMap:
-        m_Texture: {fileID: 0}
-        m_Scale: {x: 1, y: 1}
-        m_Offset: {x: 0, y: 0}
-    m_Floats:
-    - _EnableExternalAlpha: 0
-    m_Colors:
-    - _Color: {r: 1, g: 1, b: 1, a: 1}
-    - _EmissionColor: {r: 0, g: 1.0039216, b: 2.9960785, a: 1}
-    - _Flip: {r: 1, g: 1, b: 1, a: 1}
-    - _RendererColor: {r: 1, g: 1, b: 1, a: 1}
+    m_Floats: []
+    m_Colors: []
+  m_BuildTextureStacks: []

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -155,7 +155,6 @@ MonoBehaviour:
   gridWorldSize_: {x: 11, y: 11, z: 0}
   cellSize_: 1
   movementTilemapVisual_: {fileID: 1176652284}
-  player_: {fileID: 1087319437}
   tilemapVisual_: {fileID: 2098585260}
 --- !u!4 &593590128
 Transform:
@@ -394,11 +393,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: b0af036b690810680a9cceaaa13a91e6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &1087319437 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 197259336583530509, guid: d3221a1cf8229adf4b66641c061cd0a9, type: 3}
-  m_PrefabInstance: {fileID: 1667741768}
-  m_PrefabAsset: {fileID: 0}
 --- !u!114 &1176652284
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -865,7 +859,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2098585259}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0, y: 0, z: 1}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -718,6 +718,10 @@ PrefabInstance:
       propertyPath: m_BodyType
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 6024918881656354217, guid: d3221a1cf8229adf4b66641c061cd0a9, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 9f2e5ccfa489b5920bdd8989e77e18e4, type: 2}
     - target: {fileID: 9202709930041509463, guid: d3221a1cf8229adf4b66641c061cd0a9, type: 3}
       propertyPath: moveSpeed_
       value: 5
@@ -799,6 +803,10 @@ PrefabInstance:
       propertyPath: m_GravityScale
       value: 0
       objectReference: {fileID: 0}
+    - target: {fileID: 6024918881656354217, guid: d3221a1cf8229adf4b66641c061cd0a9, type: 3}
+      propertyPath: m_Materials.Array.data[0]
+      value: 
+      objectReference: {fileID: 2100000, guid: 0371a75d5ad091c33926ce0b791b838f, type: 2}
     - target: {fileID: 9202709930041509463, guid: d3221a1cf8229adf4b66641c061cd0a9, type: 3}
       propertyPath: moveSpeed_
       value: 5

--- a/Assets/Scripts/Core/GameController.cs
+++ b/Assets/Scripts/Core/GameController.cs
@@ -14,11 +14,6 @@ namespace OperationBlackwell.Core {
 		[SerializeField] private MovementTilemapVisual movementTilemapVisual_;
 		private MovementTilemap movementTilemap_;
 
-		[SerializeField] private Transform player_;
-
-		public delegate void MoveEvent(Vector3 position);
-		public event MoveEvent Moved;
-
 		public Grid<Tilemap.Node> grid { get; private set; }
 
 		public GridPathfinding gridPathfinding { get; private set; }
@@ -35,8 +30,6 @@ namespace OperationBlackwell.Core {
 
 			gridPathfinding = new GridPathfinding(origin + new Vector3(1, 1) * cellSize_ * .5f, new Vector3(gridWorldSize_.x, gridWorldSize_.y) * cellSize_, cellSize_);
 			movementTilemap_ = new MovementTilemap((int)gridWorldSize_.x, (int)gridWorldSize_.y, cellSize_, new Vector3(0, 0, 0));
-			// Node unwalkableNode = grid_.NodeFromWorldPoint(new Vector3(0, 0, 2));
-			// unwalkableNode.walkable = false;
 		}
 
 		private void Start() {

--- a/Assets/Scripts/Core/Grid.cs
+++ b/Assets/Scripts/Core/Grid.cs
@@ -89,5 +89,15 @@ namespace OperationBlackwell.Core {
 			GetXY(worldPosition, out x, out y);
 			return GetGridObject(x, y);
 		}
+
+		public List<TGridObject> GetAllGridObjects() {
+			List<TGridObject> gridObjects = new List<TGridObject>();
+			for(int x = 0; x < gridArray_.GetLength(0); x++) {
+				for(int y = 0; y < gridArray_.GetLength(1); y++) {
+					gridObjects.Add(gridArray_[x, y]);
+				}
+			}
+			return gridObjects;
+		}
 	}
 }

--- a/Assets/Scripts/Core/GridPathfinding.cs
+++ b/Assets/Scripts/Core/GridPathfinding.cs
@@ -42,11 +42,11 @@ namespace OperationBlackwell.Core {
 			worldOrigin_ = worldLowerLeft;
 			this.nodeSize_ = nodeSize_;
 
-			float worldWidth = worldUpperRight.x - worldLowerLeft.x;
-			float worldHeight = worldUpperRight.y - worldLowerLeft.y;
+			float worldWidth = worldUpperRight.x - worldLowerLeft.x + 1;
+			float worldHeight = worldUpperRight.y - worldLowerLeft.y + 1;
 
-			int mapWidth = Mathf.RoundToInt(worldWidth / nodeSize_);
-			int mapHeight = Mathf.RoundToInt(worldHeight / nodeSize_);
+			int mapWidth = (int)(worldWidth / nodeSize_);
+			int mapHeight = (int)(worldHeight / nodeSize_);
 
 			mapNodes_ = new PathNode[mapWidth][];
 			for(int i = 0; i < mapWidth; i++) {
@@ -56,6 +56,8 @@ namespace OperationBlackwell.Core {
 			heightMax_ = mapHeight;
 
 			Initialize(mapWidth, mapHeight);
+			GameController.Instance.grid.OnGridObjectChanged += OnNodeChanged;
+			GameController.Instance.tilemap.OnLoaded += OnLevelChanged;
 		}
 
 		public GridPathfinding(int mapWidth, int mapHeight, float nodeSize_, Vector3 worldOrigin_) {//, Texture2D map) {
@@ -80,6 +82,26 @@ namespace OperationBlackwell.Core {
 					if(raycastHit.collider != null) {
 						mapNodes_[i][j].SetWalkable(false);
 					}
+				}
+			}
+		}
+
+		private void OnNodeChanged(object grid, Grid<Tilemap.Node>.OnGridObjectChangedEventArgs args) {
+			int x = args.x;
+			int y = args.y;
+			Tilemap.Node node = GameController.Instance.grid.GetGridObject(x, y);
+			if(node != null && x >= 0 && x < widthMax_ && y >= 0 && y < heightMax_) {
+				mapNodes_[x][y].SetWalkable(node.walkable);
+			}
+		}
+
+		private void OnLevelChanged(object grid, System.EventArgs args) {
+			Grid<Tilemap.Node> grid_ = GameController.Instance.grid;
+			foreach(Tilemap.Node node in grid_.GetAllGridObjects()) {
+				if(node.walkable) {
+					SetWalkable(node.gridX, node.gridY, true);
+				} else {
+					SetWalkable(node.gridX, node.gridY, false);
 				}
 			}
 		}

--- a/Assets/Scripts/Player/GridCombatSystem.cs
+++ b/Assets/Scripts/Player/GridCombatSystem.cs
@@ -13,6 +13,7 @@ namespace OperationBlackwell.Player {
 		private List<UnitGridCombat> redTeamList_;
 		private int blueTeamActiveUnitIndex_;
 		private int redTeamActiveUnitIndex_;
+		private int pathLength_;
 
 		private enum State {
 			Normal,
@@ -97,6 +98,10 @@ namespace OperationBlackwell.Player {
 			int maxMoveDistance = unitGridCombat_.GetActionPoints() + 1;
 			for(int x = unitX - maxMoveDistance; x <= unitX + maxMoveDistance; x++) {
 				for(int y = unitY - maxMoveDistance; y <= unitY + maxMoveDistance; y++) {
+					// if(GameController.Instance.grid.GetGridObject(x, y).GetUnitGridCombat() != null) {
+					// 	Debug.Log("A player is already here.");
+					// 	continue;
+					// }
 					if(gridPathfinding.IsWalkable(x, y)) {
 						// Position is Walkable
 						if(gridPathfinding.HasPath(unitX, unitY, x, y)) {
@@ -146,9 +151,11 @@ namespace OperationBlackwell.Player {
 								// Set Unit on target Grid Object
 								gridObject.SetUnitGridCombat(unitGridCombat_);
 
+								pathLength_ = GameController.Instance.gridPathfinding.GetPath(unitGridCombat_.GetPosition(), Utils.GetMouseWorldPosition()).Count - 1;
+
 								unitGridCombat_.MoveTo(Utils.GetMouseWorldPosition(), () => {
 									state_ = State.Normal;
-									unitGridCombat_.SetActionPoints(unitGridCombat_.GetActionPoints() - 1);
+									unitGridCombat_.SetActionPoints(unitGridCombat_.GetActionPoints() - pathLength_);
 									UpdateValidMovePositions();
 									TestTurnOver();
 								});


### PR DESCRIPTION
This PR adds the checking for unwalkable nodes and updating the node states whenever is painted or a level is loaded. It will also feature some cleanup in the gamecontroller.

Secondly the player will update his actionpoints according to the length of the walked path.

This PR is blocked on #30 