### PR TITLE
meta: Enable MacOS, 32-bit Windows and WebGL builds on the GitHub ci

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,13 +10,13 @@ jobs:
       fail-fast: false
       matrix:
         targetPlatform:
-          # - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
-          # - StandaloneWindows # Build a Windows standalone.
+          - StandaloneOSX # Build a macOS standalone (Intel 64-bit).
+          - StandaloneWindows # Build a Windows standalone.
           - StandaloneWindows64 # Build a Windows 64-bit standalone.
           - StandaloneLinux64 # Build a Linux 64-bit standalone.
           # - iOS # Build an iOS player.
           # - Android # Build an Android .apk standalone app.
-          # - WebGL # WebGL.
+          - WebGL # WebGL.
     steps:
       - uses: actions/checkout@v2
         if: github.repository_owner == 'Online-Pluisje-Art'


### PR DESCRIPTION
This PR enables additional platforms to get pre-build binaries from GitHub ci.