### PR TITLE
meta: Change our dll filenames to match common C# naming

### DIFF
--- a/Assets/Scripts/Core/Core.asmdef
+++ b/Assets/Scripts/Core/Core.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Core",
+    "name": "OperationBlackwell.Core",
     "rootNamespace": "OperationBlackwell.Core",
     "references": [
         "GUID:c685d05731421f64287ad6d13be5af0e"

--- a/Assets/Scripts/Main.asmdef
+++ b/Assets/Scripts/Main.asmdef
@@ -1,5 +1,5 @@
 {
-    "name": "Main",
+    "name": "OperationBlackwell.Main",
     "rootNamespace": "OperationBlackwell",
     "references": [
         "GUID:f039f22f2b49b14ccbd1ae39fcf00fdb"

--- a/Assets/Tests/Tests.asmdef
+++ b/Assets/Tests/Tests.asmdef
@@ -1,10 +1,10 @@
 {
-    "name": "Tests",
+    "name": "OperationBlackwell.Tests",
     "rootNamespace": "",
     "references": [
         "UnityEngine.TestRunner",
         "UnityEditor.TestRunner",
-        "Main"
+        "OperationBlackwell.Main"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
In C#, DLL naming is usually based on namespaces. For example, Unity uses `UnityEngine.<something>.dll` as name. This PR makes us follow that naming scheme in our own DLL's.