### PR TITLE
meta: Bump version to 0.4 "Alcyone"

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.3 "Calaeno"
+  bundleVersion: 0.4 "Alcyone"
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
Starting with the 0.4 "Alcyone" development cycle.