### PR TITLE
Combat triggers

### DIFF
--- a/Assets/Resources/Prefabs/Interactables/Crate.prefab
+++ b/Assets/Resources/Prefabs/Interactables/Crate.prefab
@@ -158,5 +158,5 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   sortingOrderBase_: 5000
-  offset_: 0
+  offset_: -1
   runOnlyOnce_: 1

--- a/Assets/Resources/Prefabs/Triggers.meta
+++ b/Assets/Resources/Prefabs/Triggers.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 67abc1c4fd8392319b4ac60922bc328e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/Triggers/Combat.prefab
+++ b/Assets/Resources/Prefabs/Triggers/Combat.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &971722814146395616
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2211444462327834201}
+  - component: {fileID: -3226802398520431640}
+  m_Layer: 0
+  m_Name: Combat
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2211444462327834201
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971722814146395616}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &-3226802398520431640
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 971722814146395616}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0bb2137f1e62f354fbbd0e3a95f4ee15, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trigger_: 1

--- a/Assets/Resources/Prefabs/Triggers/Combat.prefab.meta
+++ b/Assets/Resources/Prefabs/Triggers/Combat.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: c92eabe282b4db136ba2db7c9cf453cb
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Resources/Prefabs/Triggers/Cutscene.prefab
+++ b/Assets/Resources/Prefabs/Triggers/Cutscene.prefab
@@ -1,0 +1,46 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &7302663041194414869
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 7879245417875882050}
+  - component: {fileID: 3821334394082802645}
+  m_Layer: 0
+  m_Name: Cutscene
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &7879245417875882050
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7302663041194414869}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &3821334394082802645
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7302663041194414869}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 0bb2137f1e62f354fbbd0e3a95f4ee15, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  trigger_: 2

--- a/Assets/Resources/Prefabs/Triggers/Cutscene.prefab.meta
+++ b/Assets/Resources/Prefabs/Triggers/Cutscene.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 971cfed821239075f93ad1a6ab7dd000
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -4889,15 +4889,15 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1378278090585045583, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 2.7779694
+      value: 3.5
       objectReference: {fileID: 0}
     - target: {fileID: 1378278090585045583, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 5.5558176
+      value: 18.5
       objectReference: {fileID: 0}
     - target: {fileID: 1378278090585045583, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0.21111386
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 1378278090585045583, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
       propertyPath: m_LocalRotation.w
@@ -4950,6 +4950,10 @@ PrefabInstance:
     - target: {fileID: 8827876707810031362, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
       propertyPath: m_Name
       value: Adam
+      objectReference: {fileID: 0}
+    - target: {fileID: 8827876707810031362, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
+      propertyPath: m_TagString
+      value: Player
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
@@ -5010,6 +5014,38 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 4b6d1941098387147bbdebb8f3101d4e, type: 3}
+--- !u!1 &463435884
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 463435885}
+  m_Layer: 0
+  m_Name: Triggers
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &463435885
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 463435884}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1985715751}
+  - {fileID: 1294797377}
+  m_Father: {fileID: 0}
+  m_RootOrder: 10
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &467557477
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -7688,6 +7724,72 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 6238058716552792254, guid: 0f35d99036394798ba8689ba84f9f3ca, type: 3}
   m_PrefabInstance: {fileID: 795877335}
   m_PrefabAsset: {fileID: 0}
+--- !u!1001 &738709249
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1985715751}
+    m_Modifications:
+    - target: {fileID: -3226802398520431640, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: cutsceneIndex_
+      value: -1
+      objectReference: {fileID: 0}
+    - target: {fileID: 971722814146395616, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_Name
+      value: Combat
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 7.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 16.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+--- !u!4 &738709250 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2211444462327834201, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
+  m_PrefabInstance: {fileID: 738709249}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &738877367
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -9468,7 +9570,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 957489675}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0.72203076, y: 12.944182, z: -0.21111386}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 818750476}
@@ -11998,6 +12100,37 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 564802148166850466, guid: 9d9aee4467c83b67fabf5b70dcf8e393, type: 3}
   m_PrefabInstance: {fileID: 2134649910}
   m_PrefabAsset: {fileID: 0}
+--- !u!1 &1294797376
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1294797377}
+  m_Layer: 0
+  m_Name: Cutscene
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1294797377
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1294797376}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 2093720918}
+  m_Father: {fileID: 463435885}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1296046233
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -18660,6 +18793,37 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: fe9a12e8b29f2cb5ba644d961fd951ce, type: 3}
+--- !u!1 &1985715750
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1985715751}
+  m_Layer: 0
+  m_Name: Combat
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1985715751
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1985715750}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 738709250}
+  m_Father: {fileID: 463435885}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1001 &1991866839
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -19379,6 +19543,68 @@ PrefabInstance:
 Transform:
   m_CorrespondingSourceObject: {fileID: 6238058716552792254, guid: 0f35d99036394798ba8689ba84f9f3ca, type: 3}
   m_PrefabInstance: {fileID: 1657079438}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1001 &2093720917
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 1294797377}
+    m_Modifications:
+    - target: {fileID: 7302663041194414869, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_Name
+      value: Cutscene
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 5.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 17.5
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: -0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+--- !u!4 &2093720918 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 7879245417875882050, guid: 971cfed821239075f93ad1a6ab7dd000, type: 3}
+  m_PrefabInstance: {fileID: 2093720917}
   m_PrefabAsset: {fileID: 0}
 --- !u!1001 &2097163396
 PrefabInstance:

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -4953,7 +4953,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 8827876707810031362, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
       propertyPath: m_TagString
-      value: Player
+      value: Untagged
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 901e6b7f6ba08daf59f185b6868a2d12, type: 3}
@@ -7731,10 +7731,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1985715751}
     m_Modifications:
-    - target: {fileID: -3226802398520431640, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
-      propertyPath: cutsceneIndex_
-      value: -1
-      objectReference: {fileID: 0}
     - target: {fileID: 971722814146395616, guid: c92eabe282b4db136ba2db7c9cf453cb, type: 3}
       propertyPath: m_Name
       value: Combat

--- a/Assets/Scripts/Core/Controllers/BaseCutsceneController.cs
+++ b/Assets/Scripts/Core/Controllers/BaseCutsceneController.cs
@@ -2,7 +2,7 @@ using UnityEngine;
 
 namespace OperationBlackwell.Core {
 	public class BaseCutsceneController : MonoBehaviour {
-		public virtual void StartCutscene() {
+		public virtual void StartCutscene(int index) {
 
 		}
 		

--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -381,6 +381,7 @@ namespace OperationBlackwell.Core {
 							}
 						} else if(Input.GetMouseButtonDown((int)MouseButtons.Leftclick)) {
 							DeselectUnit();
+							state_ = State.Normal;
 						}
 					} else if(gridObject.GetUnitGridCombat() != null && gridObject.GetUnitGridCombat().GetTeam() != Team.Blue) {
 						if(Input.GetMouseButtonDown((int)MouseButtons.Rightclick)) {

--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -219,9 +219,9 @@ namespace OperationBlackwell.Core {
 					if(unit != null && unitGridCombat_ != null && unitGridCombat_.CanAttackUnit(unit, Vector3.zero)
 						&& unit != unitGridCombat_ && unit.GetTeam() != unitGridCombat_.GetTeam()) {
 						CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Attack);
-					} else if(gridObject.GetIsValidMovePosition() && unitGridCombat_ != null && state_ == State.UnitSelected) {
+					} else if(gridObject.GetIsValidMovePosition() && unitGridCombat_ != null && (state_ == State.UnitSelected || state_ == State.OutOfCombat)) {
 						CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Move);
-					} else if(unit != null && unit.GetTeam() == Team.Blue && (state_ == State.Normal || state_ == State.UnitSelected)) {
+					} else if(unit != null && unit.GetTeam() == Team.Blue && (state_ == State.Normal || state_ == State.UnitSelected || state_ == State.OutOfCombat)) {
 						CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Select);
 					} else {
 						CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Arrow);
@@ -230,9 +230,9 @@ namespace OperationBlackwell.Core {
 					if(unit != null && unitGridCombat_ != null && unitGridCombat_.CanAttackUnit(unit, actions[actions.Count - 1].destinationPos)
 						&& unit != unitGridCombat_ && unit.GetTeam() != unitGridCombat_.GetTeam()) {
 						CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Attack);
-					} else if(gridObject.GetIsValidMovePosition() && unitGridCombat_ != null && state_ == State.UnitSelected) {
+					} else if(gridObject.GetIsValidMovePosition() && unitGridCombat_ != null && (state_ == State.UnitSelected || state_ == State.OutOfCombat)) {
 						CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Move);
-					} else if(unit != null && unit.GetTeam() == Team.Blue && (state_ == State.Normal || state_ == State.UnitSelected)) {
+					} else if(unit != null && unit.GetTeam() == Team.Blue && (state_ == State.Normal || state_ == State.UnitSelected || state_ == State.OutOfCombat)) {
 						CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Select);
 					} else {
 						CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Arrow);
@@ -460,7 +460,7 @@ namespace OperationBlackwell.Core {
 						gridObject.gridX, gridObject.gridY, MovementTilemap.TilemapObject.TilemapSprite.Move
 					);
 					if(Input.GetMouseButtonDown((int)MouseButtons.Rightclick)) {
-						unitGridCombat_ = null;
+						DeselectUnit();
 					}
 					if(unit != null && unit.GetTeam() == Team.Blue) {
 						if(Input.GetMouseButtonDown((int)MouseButtons.Leftclick)) {
@@ -484,10 +484,14 @@ namespace OperationBlackwell.Core {
 					}
 					if(Input.GetMouseButtonDown((int)MouseButtons.Leftclick)) {
 						if(gridObject.GetIsValidMovePosition()) {
-							grid.GetGridObject(unitGridCombat_.GetPosition()).ClearUnitGridCombat();
-							unitGridCombat_.MoveTo(Utils.GetMouseWorldPosition(), unitGridCombat_.GetPosition(), () => {
-								gridObject.SetUnitGridCombat(unitGridCombat_);
+							CoreUnit unitB = unitGridCombat_;
+							Vector3 moveFromPos = unitB.GetPosition();
+							grid.GetGridObject(unitB.GetPosition()).ClearUnitGridCombat();
+							unitB.MoveTo(Utils.GetMouseWorldPosition(), moveFromPos, () => {
+								Tilemap.Node node = grid.GetGridObject(unitB.GetPosition());
+								node.SetUnitGridCombat(unitB);
 							});
+							DeselectUnit();
 						}
 					}
 					break;

--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -58,7 +58,7 @@ namespace OperationBlackwell.Core {
 
 		private void Awake() {
 			Instance = this;
-			state_ = State.OutOfCombat;
+			state_ = State.Normal;
 			OnUnitDeath += RemoveUnitOnDeath;
 		}
 
@@ -207,10 +207,6 @@ namespace OperationBlackwell.Core {
 					}
 				}
 			}
-		}
-
-		private void FixedUpdate() {
-			CheckTriggers();
 		}
 
 		private void LateUpdate() {
@@ -499,6 +495,7 @@ namespace OperationBlackwell.Core {
 							unitB.MoveTo(Utils.GetMouseWorldPosition(), moveFromPos, () => {
 								Tilemap.Node node = grid.GetGridObject(unitB.GetPosition());
 								node.SetUnitGridCombat(unitB);
+								CheckTriggers();
 							});
 							DeselectUnit();
 						}
@@ -590,6 +587,7 @@ namespace OperationBlackwell.Core {
 			turn_++;
 			OnTurnEnded?.Invoke(this, turn_);
 			state_ = State.Normal;
+			CheckTriggers();
 		}
 
 		public void SetState(State state) {
@@ -691,14 +689,11 @@ namespace OperationBlackwell.Core {
 					continue;
 				}
 				if(trigger.GetTrigger() != TriggerNode.Trigger.None) {
-					// if(trigger.GetTrigger() == TriggerNode.Trigger.Combat && state_ == State.OutOfCombat) {
-					// 	state_ = State.Normal;
-					// } else 
 					if(trigger.GetTrigger() == TriggerNode.Trigger.Cutscene && !playedCutsceneIndexes_.Contains(trigger.GetCutsceneIndex())) {
 						cutsceneController_.StartCutscene(trigger.GetCutsceneIndex());
 						playedCutsceneIndexes_.Add(trigger.GetCutsceneIndex());
-					} else {
-						state_ = State.OutOfCombat;
+					} else if(trigger.GetTrigger() == TriggerNode.Trigger.Combat) {
+						state_ = State.Normal;
 					}
 				}
 			}

--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -534,7 +534,6 @@ namespace OperationBlackwell.Core {
 				unit = unitGridCombat_
 			};
 			OnUnitActionPointsChanged?.Invoke(this, unitEvent);
-			state_ = State.Normal;
 		}
 
 		private void ForceTurnOver() {
@@ -573,6 +572,7 @@ namespace OperationBlackwell.Core {
 			ResetAllActionPoints();
 			turn_++;
 			OnTurnEnded?.Invoke(this, turn_);
+			state_ = State.Normal;
 		}
 
 		public void SetState(State state) {

--- a/Assets/Scripts/Core/Grid/Tilemap.cs
+++ b/Assets/Scripts/Core/Grid/Tilemap.cs
@@ -7,16 +7,6 @@ namespace OperationBlackwell.Core {
 		public event System.EventHandler OnLoaded;
 
 		private Grid<Node> grid_;
-		// public int gCost;
-		// public int hCost;
-
-		// public int fCost {
-		// 	get {
-		// 		return gCost + hCost;
-		// 	}
-		// }
-
-		// public Node parent;
 
 		public Tilemap(Grid<Node> grid) {
 			this.grid_ = grid;
@@ -101,6 +91,8 @@ namespace OperationBlackwell.Core {
 
 			private Grid<Node> grid_;
 
+			private TriggerNode trigger_;
+
 			public Node(Vector3 worldPosition, int gridX, int gridY, Grid<Node> grid, bool walkable, float hitChanceModifier, bool cover) {
 				this.worldPosition = worldPosition;
 				this.gridX = gridX;
@@ -109,6 +101,7 @@ namespace OperationBlackwell.Core {
 				this.walkable = walkable;
 				this.hitChanceModifier = hitChanceModifier;
 				this.cover = cover;
+				this.trigger_ = null;
 			}
 
 			[System.Serializable]
@@ -205,6 +198,14 @@ namespace OperationBlackwell.Core {
 
 			public IInteractable GetInteractable() {
 				return interactable_;
+			}
+
+			public void SetTrigger(TriggerNode trigger) {
+				this.trigger_ = trigger;
+			}
+
+			public TriggerNode GetTrigger() {
+				return trigger_;
 			}
 		}
 	}

--- a/Assets/Scripts/Core/Grid/TriggerNode.cs
+++ b/Assets/Scripts/Core/Grid/TriggerNode.cs
@@ -1,0 +1,28 @@
+using UnityEngine;
+using System.Collections;
+
+namespace OperationBlackwell.Core {
+	public class TriggerNode : MonoBehaviour {
+		public enum Trigger {
+			None,
+			Combat,
+			Cutscene,
+		}
+		[SerializeField] private Trigger trigger_;
+		[Header("Cutscene")]
+		// Only set this if you want to use the trigger node for a cutscene. Use -1 for the combat triggers.
+		[SerializeField] private int cutsceneIndex_;
+
+		private void Start() {
+			GameController.Instance.GetGrid().GetGridObject(transform.position).SetTrigger(this);
+		}
+
+		public int GetCutsceneIndex() {
+			return cutsceneIndex_;
+		}
+
+		public Trigger GetTrigger() {
+			return trigger_;
+		}
+	}
+}

--- a/Assets/Scripts/Core/Grid/TriggerNode.cs.meta
+++ b/Assets/Scripts/Core/Grid/TriggerNode.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 0bb2137f1e62f354fbbd0e3a95f4ee15
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/Cutscenes/CutsceneController.cs
+++ b/Assets/Scripts/UI/Cutscenes/CutsceneController.cs
@@ -37,7 +37,6 @@ namespace OperationBlackwell.UI {
 
 		private void Start() {
 			currentCutscene_ = null;
-			currentCutsceneIndex_ = 0;
 			foreach(Transform child in transform) {
 				children_.Add(child.gameObject);
 			}
@@ -53,9 +52,6 @@ namespace OperationBlackwell.UI {
 			text_ = children_[9].GetComponent<TextMeshProUGUI>();
 
 			SetActive(false);
-
-			// This is here for testing now, need to remove this later.
-			StartCutscene();
 		}
 
 		private void Show(int index) {
@@ -72,15 +68,15 @@ namespace OperationBlackwell.UI {
 			SetActive(false);
 		}
 
-		public override void StartCutscene() {
+		public override void StartCutscene(int index) {
 			GridCombatSystem.Instance.SetState(GridCombatSystem.State.Cutscene);
-			Show(currentCutsceneIndex_);
+			currentCutsceneIndex_ = index;
+			Show(index);
 		}
 
 		public override void EndCutscene() {
+			GridCombatSystem.Instance.SetState(GridCombatSystem.State.OutOfCombat);
 			Hide();
-			GridCombatSystem.Instance.SetState(GridCombatSystem.State.Normal);
-			currentCutsceneIndex_++;
 		}
 
 		private void SetActive(bool active) {


### PR DESCRIPTION
This PR adds combat triggers and the same triggers are used for the activation of the cutscenes. There is one tile for the cutscene now and one where you enter the combat stage of the game. Out of combat movement is done with left click to move to a tile. The tile to show the cutscene is 1 down and 2 to the right of the players starting location, and the combat trigger tile is 1 down and 2 to the right from that tile. I really appreciate it if you test it as well.