### PR TITLE
core: Add actions for the interactables and out of combat functions

### DIFF
--- a/Assets/Scripts/Core/Unit/Actions.cs
+++ b/Assets/Scripts/Core/Unit/Actions.cs
@@ -6,6 +6,7 @@ namespace OperationBlackwell.Core {
 			None,
 			Move,
 			Attack,
+			Interact,
 		}
 
 		public enum AttackType {
@@ -86,6 +87,10 @@ namespace OperationBlackwell.Core {
 						GridCombatSystem.Instance.OnUnitActionPointsChanged?.Invoke(this, unitEvent);
 						isComplete_ = true;
 					});
+					break;
+				case ActionType.Interact:
+					IInteractable interactable = destination.GetInteractable();
+					interactable.Interact(invoker);
 					break;
 				default:
 					break;


### PR DESCRIPTION
This PR adds actions for the interactables, for now they will end your turn if in the combat phase. Otherwise the player just interacts with it. The player now also starts in the out of combat state.