### PR TITLE
core: Disable player selection at puzzles and cutscenes

### DIFF
--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -202,6 +202,10 @@ namespace OperationBlackwell.Core {
 		}
 
 		private void LateUpdate() {
+			if(state_ == State.Cutscene) {
+				CursorController.Instance.SetActiveCursorType(CursorController.CursorType.Arrow);
+				return;
+			}
 			Grid<Tilemap.Node> grid = GameController.Instance.GetGrid();
 			Tilemap.Node gridObject = grid.GetGridObject(Utils.GetMouseWorldPosition());
 			List<Actions> actions = new List<Actions>();
@@ -253,6 +257,13 @@ namespace OperationBlackwell.Core {
 			Grid<Tilemap.Node> grid = GameController.Instance.GetGrid();
 			Tilemap.Node gridObject = grid.GetGridObject(Utils.GetMouseWorldPosition());
 			CoreUnit unit;
+
+			if(state_ == State.Cutscene) {
+				GameController.Instance.GetSelectorTilemap().SetTilemapSprite(
+					prevNode_.gridX, prevNode_.gridY, MovementTilemap.TilemapObject.TilemapSprite.None
+				);
+				return;
+			}
 
 			if(gridObject == null) {
 				if(prevNode_ != null) {

--- a/Assets/Scripts/Core/Interactables/PuzzleTrigger.cs
+++ b/Assets/Scripts/Core/Interactables/PuzzleTrigger.cs
@@ -15,7 +15,7 @@ namespace OperationBlackwell.Core {
 			if(GridCombatSystem.Instance.GetState() != GridCombatSystem.State.OutOfCombat) {
 				return;
 			}
-			GridCombatSystem.Instance.SetState(GridCombatSystem.State.Waiting);
+			GridCombatSystem.Instance.SetState(GridCombatSystem.State.Cutscene);
 			PuzzleController.Instance.CreatePuzzle(puzzleIndex_);
 		}
 

--- a/Assets/Scripts/Core/Puzzles/PuzzleController.cs
+++ b/Assets/Scripts/Core/Puzzles/PuzzleController.cs
@@ -7,6 +7,9 @@ namespace OperationBlackwell.Core {
 	public class PuzzleController : MonoBehaviour {
 		public static PuzzleController Instance { get; private set; }
 
+		public System.EventHandler<System.EventArgs> PuzzleStarted;
+		public System.EventHandler<System.EventArgs> PuzzleEnded;
+
 		private Image background_;
 
 		[Header("Puzzles")]
@@ -94,6 +97,7 @@ namespace OperationBlackwell.Core {
 			}
 			input_ = new Queue<PuzzleBlock>();
 			background_.enabled = true;
+			PuzzleStarted?.Invoke(this, System.EventArgs.Empty);
 			StartShuffle();
 		}
 
@@ -102,6 +106,7 @@ namespace OperationBlackwell.Core {
 				Destroy(child.gameObject);
 			}
 			background_.enabled = false;
+			PuzzleEnded?.Invoke(this, System.EventArgs.Empty);
 			GridCombatSystem.Instance.SetState(GridCombatSystem.State.OutOfCombat);
 		}
 

--- a/Assets/Scripts/UI/HUDController.cs
+++ b/Assets/Scripts/UI/HUDController.cs
@@ -16,6 +16,8 @@ namespace OperationBlackwell.UI {
 			GridCombatSystem.Instance.OnTurnEnded += UpdateTurnCounter;
 			CutsceneController.Instance.OnCutsceneStart += HideHUD;
 			CutsceneController.Instance.OnCutsceneEnd += ShowHUD;
+			PuzzleController.Instance.PuzzleStarted += HideHUD;
+			PuzzleController.Instance.PuzzleEnded += ShowHUD;
 		}
 
 		private void OnDestroy() {
@@ -24,6 +26,8 @@ namespace OperationBlackwell.UI {
 			GridCombatSystem.Instance.OnTurnEnded -= UpdateTurnCounter;
 			CutsceneController.Instance.OnCutsceneStart -= HideHUD;
 			CutsceneController.Instance.OnCutsceneEnd -= ShowHUD;
+			PuzzleController.Instance.PuzzleStarted -= HideHUD;
+			PuzzleController.Instance.PuzzleEnded -= ShowHUD;
 		}
 
 		private void UpdateWeapon(object sender, string name) {


### PR DESCRIPTION
This PR disable the option to select players when in a cutscene and in puzzles. This way you cannot accidentally move the playable characters while in those scenes.