### PR TITLE
meta: Update version to 0.8 'Orion'

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.7 'Maia'
+  bundleVersion: 0.8 'Orion'
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
Starting with the 0.8 'Orion' development cycle.

Blocked on #99 