### PR TITLE
core: Fixes the bug where you can deadlock a player

### DIFF
--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -548,12 +548,12 @@ namespace OperationBlackwell.Core {
 							DeselectUnit();
 						} else if(gridObject.GetInteractable() != null) {
 							interactable_ = gridObject.GetInteractable();
-							prevPosition_ = unitGridCombat_.GetPosition();
 							if(interactable_.IsInRange(unitGridCombat_.GetPosition())) {
 								if(interactable_ is PuzzleTrigger puzzleTrigger) {
-									puzzleTrigger.Interact(unitGridCombat_);
 									prevPosition_ = Vector3.zero;
+									puzzleTrigger.Interact(unitGridCombat_);
 								} else {
+									prevPosition_ = unitGridCombat_.GetPosition();
 									interactable_.Interact(unitGridCombat_);
 								}
 								CheckTriggers();


### PR DESCRIPTION
This PR stops a deadlock for a player that will be created after finishing a puzzle.