### PR TITLE
puzzles: Add the option to remove objects on puzzle completion

### DIFF
--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -8395,6 +8395,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 0f35d99036394798ba8689ba84f9f3ca, type: 3}
+--- !u!1 &501077385 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2632073151736459971, guid: 2ee20f943e9fdb2d99041d1b0dfd527e, type: 3}
+  m_PrefabInstance: {fileID: 914111437}
+  m_PrefabAsset: {fileID: 0}
 --- !u!4 &507131852 stripped
 Transform:
   m_CorrespondingSourceObject: {fileID: 2379550987986703723, guid: a9f3d2e5b61a0952282a7ea5ed7c7755, type: 3}
@@ -9744,6 +9749,12 @@ MonoBehaviour:
   arrowTilemapVisual_: {fileID: 387270669}
   selectorTilemapVisual_: {fileID: 155744545}
   tilemapVisual_: {fileID: 776276069}
+  puzzleDestroyableObjects_:
+  - puzzleID: 1
+    destroyableObjects:
+    - {fileID: 968822304}
+    - {fileID: 1931799109}
+    - {fileID: 501077385}
 --- !u!4 &593590128
 Transform:
   m_ObjectHideFlags: 0
@@ -14124,6 +14135,11 @@ Transform:
 Transform:
   m_CorrespondingSourceObject: {fileID: 6982336821757750928, guid: e7f07e4cd1d6fec97a36ee6e5840ae82, type: 3}
   m_PrefabInstance: {fileID: 390357678}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &968822304 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2632073151736459971, guid: 2ee20f943e9fdb2d99041d1b0dfd527e, type: 3}
+  m_PrefabInstance: {fileID: 429988448}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &969806598 stripped
 Transform:
@@ -19656,7 +19672,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.813, y: 0.026612679}
   m_AnchorMax: {x: 0.97400004, y: 0.19558203}
-  m_AnchoredPosition: {x: 1, y: -1.2999573}
+  m_AnchoredPosition: {x: 1, y: -1.2999268}
   m_SizeDelta: {x: -2.5300002, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1430945115
@@ -19890,11 +19906,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 3969538400539265792, guid: 36b4851cfb605083e9572307460da8d7, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 20.5
+      value: 12.5
       objectReference: {fileID: 0}
     - target: {fileID: 3969538400539265792, guid: 36b4851cfb605083e9572307460da8d7, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 3.5
+      value: 18.5
       objectReference: {fileID: 0}
     - target: {fileID: 3969538400539265792, guid: 36b4851cfb605083e9572307460da8d7, type: 3}
       propertyPath: m_LocalPosition.z
@@ -27506,6 +27522,11 @@ Transform:
 Transform:
   m_CorrespondingSourceObject: {fileID: 6982336821757750928, guid: e7f07e4cd1d6fec97a36ee6e5840ae82, type: 3}
   m_PrefabInstance: {fileID: 1688533884}
+  m_PrefabAsset: {fileID: 0}
+--- !u!1 &1931799109 stripped
+GameObject:
+  m_CorrespondingSourceObject: {fileID: 2632073151736459971, guid: 2ee20f943e9fdb2d99041d1b0dfd527e, type: 3}
+  m_PrefabInstance: {fileID: 2038503431}
   m_PrefabAsset: {fileID: 0}
 --- !u!4 &1932493475 stripped
 Transform:

--- a/Assets/Scripts/Core/Controllers/GameController.cs
+++ b/Assets/Scripts/Core/Controllers/GameController.cs
@@ -9,25 +9,25 @@ namespace OperationBlackwell.Core {
 
 		public static GameController Instance { get; private set; }
 
+		[Header("World data")]
 		[SerializeField] private Vector3 gridWorldSize_;
 		[SerializeField] private float cellSize_;
-
 		[SerializeField] private bool drawGridLines_;
 
+		[Header("Map visuals")]
 		[SerializeField] private MovementTilemapVisual movementTilemapVisual_;
 		[SerializeField] private MovementTilemapVisual arrowTilemapVisual_;
 		[SerializeField] private MovementTilemapVisual selectorTilemapVisual_;
-
 		private MovementTilemap movementTilemap_;
 		private MovementTilemap arrowTilemap_;
 		private MovementTilemap selectorTilemap_;
-
 		public Grid<Tilemap.Node> grid { get; private set; }
-
 		public GridPathfinding gridPathfinding { get; private set; }
 		public Tilemap tilemap { get; private set; }
-
 		[SerializeField] private TilemapVisual tilemapVisual_;
+
+		[Header("Puzzles")]
+		[SerializeField] private List<PuzzleComplete> puzzleDestroyableObjects_;
 
 		private void Awake() {
 			grid = new Grid<Tilemap.Node>((int)gridWorldSize_.x, (int)gridWorldSize_.y, cellSize_, new Vector3(0, 0, 0), 
@@ -66,6 +66,8 @@ namespace OperationBlackwell.Core {
 			} else {
 				Debug.Log(SceneManager.GetActiveScene().name + " has no level to load!");
 			}
+
+			PuzzleController.Instance.PuzzleEnded += OnPuzzleComplete;
 		}
 
 		private void Update() {
@@ -94,5 +96,28 @@ namespace OperationBlackwell.Core {
 				SceneManager.LoadScene("MainMenu");
 			}
 		}
+
+		private void OnPuzzleComplete(object sender, PuzzleController.PuzzleEndedArgs args) {
+			PuzzleComplete? puzzleCompleted = null;
+			foreach(PuzzleComplete puzzle in puzzleDestroyableObjects_) {
+				if(puzzle.puzzleID == args.id) {
+					puzzleCompleted = puzzle;
+					break;
+				}
+			}
+			if(puzzleCompleted != null) {
+				if(puzzleCompleted.Value.destroyableObjects != null) {
+					foreach(GameObject destroyableObject in puzzleCompleted.Value.destroyableObjects) {
+						Destroy(destroyableObject);
+					}
+				}
+			}
+		}
 	}
+}
+
+[System.Serializable]
+public struct PuzzleComplete {
+	public int puzzleID;
+	public List<GameObject> destroyableObjects;
 }

--- a/Assets/Scripts/Core/Puzzles/PuzzleController.cs
+++ b/Assets/Scripts/Core/Puzzles/PuzzleController.cs
@@ -7,8 +7,12 @@ namespace OperationBlackwell.Core {
 	public class PuzzleController : MonoBehaviour {
 		public static PuzzleController Instance { get; private set; }
 
+		public class PuzzleEndedArgs : System.EventArgs {
+			public int id;
+		}
+
 		public System.EventHandler<System.EventArgs> PuzzleStarted;
-		public System.EventHandler<System.EventArgs> PuzzleEnded;
+		public System.EventHandler<PuzzleEndedArgs> PuzzleEnded;
 
 		private Image background_;
 
@@ -25,6 +29,7 @@ namespace OperationBlackwell.Core {
 			Solved
 		}
 		private PuzzleState currentState_;
+		private Puzzle currentPuzzle_;
 
 		[Header("Sizes")]
 		[SerializeField] private float puzzleSize_;
@@ -59,14 +64,15 @@ namespace OperationBlackwell.Core {
 		}
 
 		public void CreatePuzzle(int puzzleIndex) {
-			blocksPerLine_ = puzzles[puzzleIndex].BlocksPerLine();
+			currentPuzzle_ = puzzles[puzzleIndex];
+			blocksPerLine_ = currentPuzzle_.BlocksPerLine();
 			puzzleOffset_ = new Vector2(
 				puzzleSize_ / 2,
 				puzzleSize_ / 2
 			);
 			puzzleBlocks_ = new PuzzleBlock[blocksPerLine_, blocksPerLine_];
 			Texture2D[,] puzzleSlices = ImageSplicer.SplitImage(
-				Utils.TextureFromSprite(puzzles[puzzleIndex].GetSprite()),
+				Utils.TextureFromSprite(currentPuzzle_.GetSprite()),
 				blocksPerLine_
 			);
 			for(int x = 0; x < blocksPerLine_; x++) {
@@ -107,7 +113,9 @@ namespace OperationBlackwell.Core {
 			}
 			puzzleVictory_.SetActive(false);
 			background_.enabled = false;
-			PuzzleEnded?.Invoke(this, System.EventArgs.Empty);
+			PuzzleEnded?.Invoke(this, new PuzzleEndedArgs {
+				id = currentPuzzle_.GetID()
+			});
 			GridCombatSystem.Instance.SetState(GridCombatSystem.State.OutOfCombat);
 		}
 
@@ -131,7 +139,6 @@ namespace OperationBlackwell.Core {
 					MakeNextMove();
 				}
 			}
-			
 
 			if(shuffleCountRemaining_ > 0) {
 				MakeNextShuffleMove();

--- a/Assets/Scripts/Core/Utils/PrefabStatus.cs
+++ b/Assets/Scripts/Core/Utils/PrefabStatus.cs
@@ -18,5 +18,12 @@ namespace OperationBlackwell.Core {
             GameController.Instance.grid.TriggerGridObjectChanged(x, y);
             GridPathfinding.Instance.SetWalkable(x, y, walkable_);
         }
+
+        private void OnDestroy() {
+            int x, y;
+            GameController.Instance.grid.GetXY(transform.position, out x, out y);
+            GameController.Instance.grid.TriggerGridObjectChanged(x, y);
+            GridPathfinding.Instance.SetWalkable(x, y, true);
+        }
     }
 }


### PR DESCRIPTION
This PR add the option to remove certain objects from the scene once a puzzle is completed. This is done by puzzle ID and by setting the correct ID in the list with the objects you would like to destroy in the gamecontroller it will be handled for you.