### PR TITLE
QoL changes

### DIFF
--- a/Assets/Resources/Prefabs/Interactables/Puzzle.prefab
+++ b/Assets/Resources/Prefabs/Interactables/Puzzle.prefab
@@ -112,6 +112,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 192190478874319631}
+  - {fileID: 5216882349582591045}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -145,3 +146,85 @@ MonoBehaviour:
   range_: 1
   cost_: 0
   puzzleIndex_: 0
+--- !u!1 &5465637022171116511
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5216882349582591045}
+  - component: {fileID: 6089947581912363787}
+  m_Layer: 0
+  m_Name: Body solved
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &5216882349582591045
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5465637022171116511}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 3, y: 3, z: 1}
+  m_Children: []
+  m_Father: {fileID: 3969538400539265792}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &6089947581912363787
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5465637022171116511}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: 0
+  m_SortingLayer: 0
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 72bfe181c13c54845b7abf406fa42c29, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -3777,11 +3777,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 6884121164622706816, guid: fd813534084e8c89db9eef4d9aa72aef, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 19.5
+      value: 1.5
       objectReference: {fileID: 0}
     - target: {fileID: 6884121164622706816, guid: fd813534084e8c89db9eef4d9aa72aef, type: 3}
       propertyPath: m_LocalPosition.y
-      value: 4.5
+      value: 19.5
       objectReference: {fileID: 0}
     - target: {fileID: 6884121164622706816, guid: fd813534084e8c89db9eef4d9aa72aef, type: 3}
       propertyPath: m_LocalPosition.z
@@ -4547,6 +4547,10 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1911180824}
     m_Modifications:
+    - target: {fileID: 258371717185868148, guid: 232a1537f78d2e27ea649faecefd494c, type: 3}
+      propertyPath: m_AnchoredPosition.x
+      value: 1.1398926
+      objectReference: {fileID: 0}
     - target: {fileID: 1942434042043666953, guid: 232a1537f78d2e27ea649faecefd494c, type: 3}
       propertyPath: cutscenes_.Array.size
       value: 10
@@ -4592,8 +4596,8 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 11400000, guid: 087b9de55289c5d42a185e9a09cafe51, type: 2}
     - target: {fileID: 2649961574864912726, guid: 232a1537f78d2e27ea649faecefd494c, type: 3}
-      propertyPath: m_AnchoredPosition.x
-      value: -39.77182
+      propertyPath: m_LocalPosition.x
+      value: -759.22015
       objectReference: {fileID: 0}
     - target: {fileID: 4370431012621421263, guid: 232a1537f78d2e27ea649faecefd494c, type: 3}
       propertyPath: m_Name
@@ -4601,7 +4605,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5835565001710078823, guid: 232a1537f78d2e27ea649faecefd494c, type: 3}
       propertyPath: m_AnchoredPosition.y
-      value: -1.2999878
+      value: -1.2999268
       objectReference: {fileID: 0}
     - target: {fileID: 7992229420140485011, guid: 232a1537f78d2e27ea649faecefd494c, type: 3}
       propertyPath: m_Pivot.x
@@ -11738,7 +11742,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 626258690}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 19.81, y: 5.29, z: -10}
+  m_LocalPosition: {x: 1.5, y: 19.5, z: -10}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 0}
@@ -17745,7 +17749,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: -811.00006, y: -415}
+  m_AnchoredPosition: {x: -811.0001, y: -415}
   m_SizeDelta: {x: -1260.26, y: -589.92}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1016170550

--- a/Assets/Scenes/TutorialLevel.unity
+++ b/Assets/Scenes/TutorialLevel.unity
@@ -4597,7 +4597,7 @@ PrefabInstance:
       objectReference: {fileID: 11400000, guid: 087b9de55289c5d42a185e9a09cafe51, type: 2}
     - target: {fileID: 2649961574864912726, guid: 232a1537f78d2e27ea649faecefd494c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: -759.22015
+      value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4370431012621421263, guid: 232a1537f78d2e27ea649faecefd494c, type: 3}
       propertyPath: m_Name
@@ -24301,10 +24301,6 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 1862699913}
     m_Modifications:
-    - target: {fileID: 2160969972717473138, guid: 36b4851cfb605083e9572307460da8d7, type: 3}
-      propertyPath: puzzleIndex_
-      value: 0
-      objectReference: {fileID: 0}
     - target: {fileID: 3969538400539265792, guid: 36b4851cfb605083e9572307460da8d7, type: 3}
       propertyPath: m_RootOrder
       value: 2
@@ -24352,6 +24348,10 @@ PrefabInstance:
     - target: {fileID: 4194922723558346020, guid: 36b4851cfb605083e9572307460da8d7, type: 3}
       propertyPath: m_Name
       value: Puzzle
+      objectReference: {fileID: 0}
+    - target: {fileID: 5465637022171116511, guid: 36b4851cfb605083e9572307460da8d7, type: 3}
+      propertyPath: m_IsActive
+      value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 36b4851cfb605083e9572307460da8d7, type: 3}

--- a/Assets/Scripts/AI/AIController.cs
+++ b/Assets/Scripts/AI/AIController.cs
@@ -23,12 +23,17 @@ namespace OperationBlackwell.AI {
 			// Subscribe to events
 			if(GridCombatSystem.instance != null) {
 				GridCombatSystem.instance.AIStageLoaded += OnAIStageLoaded;
+				GridCombatSystem.instance.AIStageUnloaded += OnAIStageUnloaded;
 				GridCombatSystem.instance.AISetTurn += OnAISetTurn;
 			}
 		}
 
 		private void OnAIStageLoaded(object sender, int stage) {
 			LoadStage(stage);
+		}
+
+		private void OnAIStageUnloaded(object sender, int stage) {
+			UnloadStage();
 		}
 
 		private void OnAISetTurn(object sender, System.EventArgs e) {
@@ -96,7 +101,7 @@ namespace OperationBlackwell.AI {
 				// For now we will just have the unit move to the nearest enemy. Or attack the nearest enemy.
 				// (This depends if the unit has enough action points and if the unit is in range of the enemy)
 				while(unit.HasActionPoints()) {
-					// The == 1 is because each tile to move has a cost of 2 and otherwise we would end up in a deadlock.
+					// The <= 1 is because each tile to move has a cost of 2 and otherwise we would end up in a deadlock.
 					if(unit.GetActionPoints() <= 1) {
 						break;
 					}

--- a/Assets/Scripts/Core/Controllers/GameController.cs
+++ b/Assets/Scripts/Core/Controllers/GameController.cs
@@ -28,7 +28,7 @@ namespace OperationBlackwell.Core {
 		[Header("Puzzles")]
 		[SerializeField] private List<PuzzleComplete> puzzleDestroyableObjects_;
 		public System.EventHandler<PuzzleCompleteArgs> PuzzleEnded;
-		public System.EventHandler<System.EventArgs> PuzzleCompleted;
+		public System.EventHandler<int> PuzzleCompleted;
 
 		public class PuzzleCompleteArgs : System.EventArgs {
 			public int id;
@@ -109,7 +109,7 @@ namespace OperationBlackwell.Core {
 					foreach(GameObject destroyableObject in puzzle.destroyableObjects) {
 						Destroy(destroyableObject);
 					}
-					PuzzleCompleted?.Invoke(this, System.EventArgs.Empty);
+					PuzzleCompleted?.Invoke(this, args.id);
 					break;
 				}
 			}

--- a/Assets/Scripts/Core/Controllers/GameController.cs
+++ b/Assets/Scripts/Core/Controllers/GameController.cs
@@ -27,7 +27,13 @@ namespace OperationBlackwell.Core {
 
 		[Header("Puzzles")]
 		[SerializeField] private List<PuzzleComplete> puzzleDestroyableObjects_;
-		public System.EventHandler<int> PuzzleEnded;
+		public System.EventHandler<PuzzleCompleteArgs> PuzzleEnded;
+		public System.EventHandler<System.EventArgs> PuzzleCompleted;
+
+		public class PuzzleCompleteArgs : System.EventArgs {
+			public int id;
+			public bool success;
+		}
 
 		[Header("Cursor")]
 		public EventHandler<string> CursorChanged;
@@ -97,12 +103,13 @@ namespace OperationBlackwell.Core {
 			}
 		}
 
-		private void OnPuzzleComplete(object sender, int id) {
+		private void OnPuzzleComplete(object sender, PuzzleCompleteArgs args) {
 			foreach(PuzzleComplete puzzle in puzzleDestroyableObjects_) {
-				if(puzzle.puzzleID == id) {
+				if(puzzle.puzzleID == args.id && args.success) {
 					foreach(GameObject destroyableObject in puzzle.destroyableObjects) {
 						Destroy(destroyableObject);
 					}
+					PuzzleCompleted?.Invoke(this, System.EventArgs.Empty);
 					break;
 				}
 			}

--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -122,61 +122,14 @@ namespace OperationBlackwell.Core {
 			} else {
 				redTeamList_.Remove(unit);
 				if(redTeamList_.Count <= 0) {
-					// aiController_.UnloadStage();
+					AIStageUnloaded?.Invoke(this, 0);
+					state_ = State.OutOfCombat;
 				}
 			}
 			orderList_.GetQueue().RemoveAll(x => x.GetUnit() == unit);
 			Grid<Tilemap.Node> grid = GameController.instance.GetGrid();
 			Tilemap.Node gridObject = grid.GetGridObject(unit.GetPosition());
 			gridObject.ClearUnitGridCombat();
-		}
-
-		private void SelectNextActiveUnit() {
-			if(unitGridCombat_ == null || unitGridCombat_.GetTeam() == Team.Red) {
-				unitGridCombat_ = GetNextActiveUnit(Team.Blue);
-			} else {
-				unitGridCombat_ = GetNextActiveUnit(Team.Red);
-			}
-
-			UnitEvent unitEvent = new UnitEvent() {
-				unit = unitGridCombat_
-			};
-			OnUnitActionPointsChanged?.Invoke(this, unitEvent);
-			OnWeaponChanged?.Invoke(this, unitGridCombat_.GetActiveWeapon());
-		}
-
-		private CoreUnit GetNextActiveUnit(Team team) {
-			if(team == Team.Blue) {
-				if(blueTeamList_.Count == 0) {
-					return GetNextActiveUnit(Team.Red);
-				} else {
-					blueTeamActiveUnitIndex_ = (blueTeamActiveUnitIndex_ + 1) % blueTeamList_.Count;
-					return GetUnitTeam(blueTeamList_, blueTeamActiveUnitIndex_, team);
-				}
-			} else {
-				if(redTeamList_.Count == 0) {
-					return GetNextActiveUnit(Team.Blue);
-				} else {
-					redTeamActiveUnitIndex_ = (redTeamActiveUnitIndex_ + 1) % redTeamList_.Count;
-					return GetUnitTeam(redTeamList_, redTeamActiveUnitIndex_, team);
-				}
-			}
-		}
-
-		private CoreUnit GetUnitTeam(List<CoreUnit> teamList, int index, Team team) {
-			if(index < 0 || index >= teamList.Count) {
-				return null;
-			}
-			if(teamList[index] == null || teamList[index].IsDead()) {
-				// Unit is Dead, get next one
-				return GetNextActiveUnit(team);
-			} else {
-				OnUnitSelect?.Invoke(this, new UnitPositionEvent() {
-					unit = teamList[index],
-					position = teamList[index].GetPosition()
-				});
-				return teamList[index];
-			}
 		}
 
 		public void UpdateValidMovePositions(Vector3 position) {

--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -54,6 +54,7 @@ namespace OperationBlackwell.Core {
 		private Vector3 prevPosition_;
 		private int prevActionCount_;
 		private bool setAiTurn_;
+		private bool firstUpdate_;
 
 		public enum State {
 			Normal,
@@ -94,6 +95,8 @@ namespace OperationBlackwell.Core {
 			state_ = State.OutOfCombat;
 			OnUnitDeath += RemoveUnitOnDeath;
 			AITurnSet += OnAITurnSet;
+
+			firstUpdate_ = true;
 		}
 
 		private void OnDestroy() {
@@ -217,11 +220,15 @@ namespace OperationBlackwell.Core {
 		}
 
 		private void Update() {
+			if(firstUpdate_) {
+				firstUpdate_ = false;
+				CheckTriggers();
+			}
 			Grid<Tilemap.Node> grid = GameController.instance.GetGrid();
 			Tilemap.Node gridObject = grid.GetGridObject(Utils.GetMouseWorldPosition());
 			CoreUnit unit;
 
-			if(state_ == State.Cutscene) {
+			if(state_ == State.Cutscene && prevNode_ != null) {
 				GameController.instance.GetSelectorTilemap().SetTilemapSprite(
 					prevNode_.gridX, prevNode_.gridY, MovementTilemap.TilemapObject.TilemapSprite.None
 				);
@@ -703,6 +710,7 @@ namespace OperationBlackwell.Core {
 					if(trigger.GetTrigger() == TriggerNode.Trigger.Cutscene && !playedCutsceneIndexes_.Contains(trigger.GetIndex())) {
 						CutsceneTriggered?.Invoke(this, trigger.GetIndex());
 						playedCutsceneIndexes_.Add(trigger.GetIndex());
+						state_ = State.Cutscene;
 					} else if(trigger.GetTrigger() == TriggerNode.Trigger.Combat) {
 						state_ = State.Normal;
 						AIStageLoaded?.Invoke(this, trigger.GetIndex());

--- a/Assets/Scripts/Core/Interactables/PuzzleTrigger.cs
+++ b/Assets/Scripts/Core/Interactables/PuzzleTrigger.cs
@@ -1,5 +1,6 @@
 using UnityEngine;
 using System.Collections;
+using System.Collections.Generic;
 
 namespace OperationBlackwell.Core {
 	public class PuzzleTrigger : MonoBehaviour, IInteractable {
@@ -9,12 +10,25 @@ namespace OperationBlackwell.Core {
 
 		public static event System.EventHandler<int> PuzzleLaunched;
 
+		private List<Transform> children_;
+		private bool solved_;
+
 		private void Start() {
 			GameController.instance.GetGrid().GetGridObject(transform.position).SetInteractable(this);
+			children_ = new List<Transform>();
+			solved_ = false;
+			foreach(Transform child in transform) {
+				children_.Add(child);
+			}
+			GameController.instance.PuzzleCompleted += OnPuzzleCompleted;
+		}
+
+		private void OnDestroy() {
+			GameController.instance.PuzzleCompleted -= OnPuzzleCompleted;
 		}
 
 		public void Interact(CoreUnit unit) {
-			if(GridCombatSystem.instance.GetState() != GridCombatSystem.State.OutOfCombat) {
+			if(solved_ || GridCombatSystem.instance.GetState() != GridCombatSystem.State.OutOfCombat) {
 				return;
 			}
 			GridCombatSystem.instance.SetState(GridCombatSystem.State.Cutscene);
@@ -29,6 +43,12 @@ namespace OperationBlackwell.Core {
 
 		public int GetCost() {
 			return cost_;
+		}
+
+		private void OnPuzzleCompleted(object sender, System.EventArgs args) {
+			children_[0].gameObject.SetActive(false);
+			children_[1].gameObject.SetActive(true);
+			solved_ = true;
 		}
 	}
 }

--- a/Assets/Scripts/Core/Interactables/PuzzleTrigger.cs
+++ b/Assets/Scripts/Core/Interactables/PuzzleTrigger.cs
@@ -45,7 +45,10 @@ namespace OperationBlackwell.Core {
 			return cost_;
 		}
 
-		private void OnPuzzleCompleted(object sender, System.EventArgs args) {
+		private void OnPuzzleCompleted(object sender, int id) {
+			if(puzzleIndex_ != id) {
+				return;
+			}
 			children_[0].gameObject.SetActive(false);
 			children_[1].gameObject.SetActive(true);
 			solved_ = true;

--- a/Assets/Scripts/Player/AIUnit.cs
+++ b/Assets/Scripts/Player/AIUnit.cs
@@ -14,21 +14,10 @@ namespace OperationBlackwell.Player {
 
 		private Weapon currentWeapon_;
 
-		private bool shouldPlayAttackAnimation_ = false;
-		private Direction direction_ = Direction.Null;
-
 		private AudioSource audioSource_;
 		private string animatorClipName_ = "";
 
 		private bool enabled_;
-
-		private enum Direction {
-			Up,
-			Down,
-			Left,
-			Right,
-			Null
-		}
 
 		private void Awake() {
 			movePosition_ = GetComponent<MovePositionPathfinding>();
@@ -150,69 +139,6 @@ namespace OperationBlackwell.Player {
 			onShootComplete();
 
 			GetComponent<IMoveVelocity>().Enable();
-		}
-
-		private void DetermineAttackAnimation(CoreUnit unitGridCombat) {
-			shouldPlayAttackAnimation_ = true;
-			Vector3 attackerPosition = this.GetPosition();
-			Vector3 enemyPosition = unitGridCombat.GetPosition();
-			direction_ = Direction.Null;
-			int diffX = 0;
-			int diffY = 0;
-			// 0 is neither, 1 is yes, 2 is false.
-			int isBelow = 0;
-			int isLeft = 0;
-			if(attackerPosition.x == enemyPosition.x) {
-				// Either above or below us.
-			} else if(attackerPosition.x > enemyPosition.x) {
-				// Left of us.
-				diffX = (int)(attackerPosition.x - enemyPosition.x);
-				isLeft = 1;
-			} else {
-				// Right of us.
-				diffX = (int)(enemyPosition.x - attackerPosition.x);
-				isLeft = 2;
-			}
-			if(attackerPosition.y == enemyPosition.y) {
-				// Either left or right of us.
-			} else if(attackerPosition.y > enemyPosition.y) {
-				// Below us.
-				diffY = (int)(attackerPosition.y - enemyPosition.y);
-				isBelow = 1;
-			} else {
-				// Above us.
-				diffY = (int)(enemyPosition.y - attackerPosition.y);
-				isBelow = 2;
-			}
-			// Depending on which diff is bigger, trigger the right direction.
-			if(diffX > diffY) {
-				// Left/Right is bigger than up/down, use left/right.
-				if(isLeft == 1) {
-					// Left it is!
-					direction_ = Direction.Left;
-				} else if(isLeft == 2) {
-					// Right it is!
-					direction_ = Direction.Right;
-				} else {
-					// Should never happen, signal an error.
-					direction_ = Direction.Null;
-				}
-			} else if(diffX <= diffY) {
-				// Up/down is bigger or equal to left/right, use up/down.
-				if(isBelow == 1) {
-					// Below it is!
-					direction_ = Direction.Down;
-				} else if(isBelow == 2) {
-					// Up it is!
-					direction_ = Direction.Up;
-				} else {
-					// Should never happen, signal an error.
-					direction_ = Direction.Null;
-				}
-			} else {
-				// Should never happen, signal an error.
-				direction_ = Direction.Null;
-			}
 		}
 
 		public override int GetAttackCost() {

--- a/Assets/Scripts/Player/UnitGridCombat.cs
+++ b/Assets/Scripts/Player/UnitGridCombat.cs
@@ -14,20 +14,9 @@ namespace OperationBlackwell.Player {
 		private WorldBar healthBar_;
 
 		private Weapon currentWeapon_;
-		
-		private bool shouldPlayAttackAnimation_ = false;
-		private Direction direction_ = Direction.Null;
 
 		private AudioSource audioSource_;
 		private string animatorClipName_ = "";
-
-		private enum Direction {
-			Up,
-			Down,
-			Left,
-			Right,
-			Null
-		}
 
 		private void Awake() {
 			movePosition_ = GetComponent<MovePositionPathfinding>();
@@ -144,69 +133,6 @@ namespace OperationBlackwell.Player {
 			onShootComplete();
 
 			GetComponent<IMoveVelocity>().Enable();
-		}
-
-		private void DetermineAttackAnimation(CoreUnit unitGridCombat) {
-			shouldPlayAttackAnimation_ = true;
-			Vector3 attackerPosition = this.GetPosition();
-			Vector3 enemyPosition = unitGridCombat.GetPosition();
-			direction_ = Direction.Null;
-			int diffX = 0;
-			int diffY = 0;
-			// 0 is neither, 1 is yes, 2 is false.
-			int isBelow = 0;
-			int isLeft = 0;
-			if(attackerPosition.x == enemyPosition.x) {
-				// Either above or below us.
-			} else if(attackerPosition.x > enemyPosition.x) {
-				// Left of us.
-				diffX = (int)(attackerPosition.x - enemyPosition.x);
-				isLeft = 1;
-			} else {
-				// Right of us.
-				diffX = (int)(enemyPosition.x - attackerPosition.x);
-				isLeft = 2;
-			}
-			if(attackerPosition.y == enemyPosition.y) {
-				// Either left or right of us.
-			} else if(attackerPosition.y > enemyPosition.y) {
-				// Below us.
-				diffY = (int)(attackerPosition.y - enemyPosition.y);
-				isBelow = 1;
-			} else {
-				// Above us.
-				diffY = (int)(enemyPosition.y - attackerPosition.y);
-				isBelow = 2;
-			}
-			// Depending on which diff is bigger, trigger the right direction.
-			if(diffX > diffY) {
-				// Left/Right is bigger than up/down, use left/right.
-				if(isLeft == 1) {
-					// Left it is!
-					direction_ = Direction.Left;
-				} else if(isLeft == 2) {
-					// Right it is!
-					direction_ = Direction.Right;
-				} else {
-					// Should never happen, signal an error.
-					direction_ = Direction.Null;
-				}
-			} else if(diffX <= diffY) {
-				// Up/down is bigger or equal to left/right, use up/down.
-				if(isBelow == 1) {
-					// Below it is!
-					direction_ = Direction.Down;
-				} else if(isBelow == 2) {
-					// Up it is!
-					direction_ = Direction.Up;
-				} else {
-					// Should never happen, signal an error.
-					direction_ = Direction.Null;
-				}
-			} else {
-				// Should never happen, signal an error.
-				direction_ = Direction.Null;
-			}
 		}
 
 		[ContextMenu("Test")]

--- a/Assets/Scripts/Puzzles/PuzzleController.cs
+++ b/Assets/Scripts/Puzzles/PuzzleController.cs
@@ -126,7 +126,10 @@ namespace OperationBlackwell.Puzzles {
 			puzzleVictory_.SetActive(false);
 			puzzleTimer_.SetActive(false);
 			background_.enabled = false;
-			GameController.instance.PuzzleEnded?.Invoke(this, currentPuzzle_.GetID());
+			GameController.instance.PuzzleEnded?.Invoke(this, new GameController.PuzzleCompleteArgs {
+				id = currentPuzzle_.GetID(),
+				success = (currentState_ == PuzzleState.Solved)
+			});
 			GridCombatSystem.instance.SetState(GridCombatSystem.State.OutOfCombat);
 			timerScript_.StopTimer();
 		}


### PR DESCRIPTION
This PR adds the functionality to trigger a cutscene or combat stage if the player spawns on a trigger. It also moves functions that are both present in the unit and AI unit to the core unit they both inherit from. Next to this it adds back the functionality to unload stages for the AI controller once all the active units are dead. Next to this the puzzle triggers now show a solved state as the tile and do not trigger a puzzle again once solved.