### PR TITLE
AI

### DIFF
--- a/Assets/Scripts/Player/AIUnit.cs
+++ b/Assets/Scripts/Player/AIUnit.cs
@@ -22,6 +22,7 @@ namespace OperationBlackwell.Player {
 			movePosition_ = GetComponent<MovePositionPathfinding>();
 			healthBar_ = new WorldBar(transform, new Vector3(0, 6.6f), new Vector3(1, .13f), Color.grey, Color.red, 1f, 10000, new WorldBar.Outline { color = Color.black, size = .05f });
 			enabled_ = false;
+			healthBar_.Hide();
 			base.Awake();
 		}
 
@@ -252,6 +253,7 @@ namespace OperationBlackwell.Player {
 
 		public void LoadUnit() {
 			enabled_ = true;
+			healthBar_.Show();
 		}
 
 		public bool GetLoaded() {

--- a/Assets/Scripts/Player/UnitGridCombat.cs
+++ b/Assets/Scripts/Player/UnitGridCombat.cs
@@ -63,7 +63,7 @@ namespace OperationBlackwell.Player {
 			 * when its the same node it returns 1 so we subtract one from the distance to get the actual distance.
 			 * If the distance is less or equal than the weapon range, return true.
 			 */
-			if(unitGridCombat == null || unitGridCombat.GetTeam() == team_ || actionPoints_ <= currentWeapon_.GetMaxCost()) {
+			if(unitGridCombat == null || unitGridCombat.GetTeam() == team_ || actionPoints_ <= currentWeapon_.GetMaxCost() || !((AIUnit)unitGridCombat).GetLoaded()) {
 				return false;
 			}
 


### PR DESCRIPTION
This PR stops the player from attacking enemies that are not active in the current combat stage. All the enemies hide their healthbar by default and it will only show for the units that are loaded into the current combat scene.