### PR TITLE
meta: Bump version to 1.0 Atlas

### DIFF
--- a/ProjectSettings/ProjectSettings.asset
+++ b/ProjectSettings/ProjectSettings.asset
@@ -134,7 +134,7 @@ PlayerSettings:
     16:10: 1
     16:9: 1
     Others: 1
-  bundleVersion: 0.9 'Pleione'
+  bundleVersion: 1.0 'Atlas'
   preloadedAssets: []
   metroInputSource: 0
   wsaTransparentSwapchain: 0


### PR DESCRIPTION
As we're getting close to the final release, let's bump the version number to 1.0.