### PR TITLE
core: Fixes issue with returning to normal state

### DIFF
--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -270,14 +270,12 @@ namespace OperationBlackwell.Core {
 					unit = gridObject.GetUnitGridCombat();
 					if(unit != null && unit.GetTeam() == Team.Blue) {
 						if(Input.GetMouseButtonDown((int)MouseButtons.Leftclick)) {
-							if(unit != null && unit.GetTeam() == Team.Blue) {
-								OnUnitSelect?.Invoke(this, new UnitPositionEvent() {
-									unit = unit,
-									position = unit.GetPosition()
-								});
-								unitGridCombat_ = unit;
-								state_ = State.UnitSelected;
-							}
+							OnUnitSelect?.Invoke(this, new UnitPositionEvent() {
+								unit = unit,
+								position = unit.GetPosition()
+							});
+							unitGridCombat_ = unit;
+							state_ = State.UnitSelected;
 						}
 					}
 					break;

--- a/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
+++ b/Assets/Scripts/Core/Controllers/GridCombatSystem.cs
@@ -596,6 +596,7 @@ namespace OperationBlackwell.Core {
 		}
 
 		IEnumerator ExecuteAllActionsCoroutine() {
+			state_ = State.Normal;
 			bool hasExecuted = false;
 			bool isComplete = false;
 			// Sort the orderlist queue by initiative
@@ -626,7 +627,6 @@ namespace OperationBlackwell.Core {
 			ResetAllActionPoints();
 			turn_++;
 			OnTurnEnded?.Invoke(this, turn_);
-			state_ = State.Normal;
 			OnUnitSelect?.Invoke(this, new UnitPositionEvent() {
 				unit = loadCamUnit_,
 				position = loadCamUnit_.GetPosition()


### PR DESCRIPTION
This PR fixes the issue that the game would return to the combat state after all enemies that were activated were killed. This was due the event on unit death was fired before the end of the execute all actions, this made the game so that on the unit death the game moves to out of combat and once all actions are done back to normal. This is now fixed and the game returns to the correct state.